### PR TITLE
Add swipe component and gesture recognizers

### DIFF
--- a/samples/Avalonia.Labs.Catalog/Avalonia.Labs.Catalog.csproj
+++ b/samples/Avalonia.Labs.Catalog/Avalonia.Labs.Catalog.csproj
@@ -26,4 +26,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Avalonia.Labs.Controls\Avalonia.Labs.Controls.csproj" />
   </ItemGroup>
+
 </Project>

--- a/samples/Avalonia.Labs.Catalog/ViewModels/GestureViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/GestureViewModel.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using Avalonia.Labs.Catalog.Views;
+namespace Avalonia.Labs.Catalog.ViewModels;
+
+public class GestureViewModel : ViewModelBase
+{
+    static GestureViewModel()
+    {
+        ViewLocator.Register(typeof(GestureViewModel), () => new GestureContainerView());
+    }
+
+    public GestureViewModel()
+    {
+        Title = "Gesture";
+        Items = Enumerable.Range(0, 10).ToArray();
+    }
+
+    public int[] Items
+    {
+        get;
+        set;
+    }
+}

--- a/samples/Avalonia.Labs.Catalog/ViewModels/SwipeViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/SwipeViewModel.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using Avalonia.Labs.Catalog.Views;
+
+namespace Avalonia.Labs.Catalog.ViewModels;
+
+public class SwipeViewModel : ViewModelBase
+{
+    static SwipeViewModel()
+    {
+        ViewLocator.Register(typeof(SwipeViewModel), () => new SwipeView());
+    }
+
+    public SwipeViewModel()
+    {
+        Title = "Swipe";
+        Items = Enumerable.Range(0, 20).ToArray();
+    }
+
+    public int[] Items
+    {
+        get;
+        set;
+    }
+}

--- a/samples/Avalonia.Labs.Catalog/Views/GestureContainerView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/GestureContainerView.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:Avalonia.Labs.Catalog.Views"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Avalonia.Labs.Catalog.Views.GestureContainerView">
+  <ScrollViewer>
+    <ItemsControl Items="{Binding Items}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+         <views:GestureView Height="400" />
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </ScrollViewer>
+</UserControl>
+

--- a/samples/Avalonia.Labs.Catalog/Views/GestureContainerView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/GestureContainerView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Labs.Catalog.Views;
+
+public partial class GestureContainerView : UserControl
+{
+    public GestureContainerView()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/samples/Avalonia.Labs.Catalog/Views/GestureView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/GestureView.axaml
@@ -1,0 +1,41 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:base="clr-namespace:Avalonia.Labs.Controls.Base;assembly=Avalonia.Labs.Controls"
+             xmlns:pan="clr-namespace:Avalonia.Labs.Controls.Base.Pan;assembly=Avalonia.Labs.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Avalonia.Labs.Catalog.Views.GestureView">
+  <Grid>
+    <Border Background="Red" Height="128" Width="128" VerticalAlignment="Center" HorizontalAlignment="Left">
+      <Border.GestureRecognizers>
+        <base:TapGestureRecognizer OnTap="Pressed" DetectOn="PointerPressed" />
+      </Border.GestureRecognizers>
+      <Label x:Name="RedActionText" Content="Click" VerticalAlignment="Top" />
+    </Border>
+
+    <Border Background="Blue" Height="128" Width="128" VerticalAlignment="Center" HorizontalAlignment="Center">
+      <Border.GestureRecognizers>
+        <base:TapGestureRecognizer OnTap="Released" />
+      </Border.GestureRecognizers>
+      <Label x:Name="BlueActionText" Content="Click" VerticalAlignment="Top" />
+    </Border>
+
+    <Border x:Name="Green" Background="Green" Height="128" Width="128" VerticalAlignment="Center"
+            HorizontalAlignment="Right">
+      <Border.GestureRecognizers>
+        <pan:PanGestureRecognizer OnPan="Panned" />
+      </Border.GestureRecognizers>
+      <Label x:Name="GreenActionText" Content="Grab" />
+    </Border>
+
+    <Border x:Name="Orange" Background="Orange" Height="128" Width="128" VerticalAlignment="Bottom"
+            HorizontalAlignment="Center">
+      <Border.GestureRecognizers>
+        <base:TapGestureRecognizer OnTap="ReleasedOrange" />
+        <pan:PanGestureRecognizer OnPan="PannedOrange" />
+      </Border.GestureRecognizers>
+      <Label x:Name="OrangeActionText" Content="Tap or Grab" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/samples/Avalonia.Labs.Catalog/Views/GestureView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/GestureView.axaml.cs
@@ -1,0 +1,65 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Labs.Controls.Base;
+using Avalonia.Labs.Controls.Base.Pan;
+using Avalonia.Media.Transformation;
+
+namespace Avalonia.Labs.Catalog.Views;
+
+public partial class GestureView : UserControl
+{
+    private Point _startPosition;
+
+    public GestureView()
+    {
+        InitializeComponent();
+    }
+
+    private void Pressed(object? sender, TapEventArgs e)
+    {
+        RedActionText.Content = $"Tap at {e.Position}";
+    }
+
+    private void Released(object? sender, TapEventArgs e)
+    {
+        BlueActionText.Content = $"Tap at {e.Position}";
+    }
+
+    private void Panned(object? sender, PanUpdatedEventArgs e)
+    {
+        WritePan(GreenActionText, Green, e);
+    }
+
+    private void WritePan(Label label, Border border, PanUpdatedEventArgs e)
+    {
+        switch (e.StatusType)
+        {
+            case PanGestureStatus.Started:
+                label.Content = $"S: {_startPosition.X} + {e.TotalX}, {_startPosition.Y} + {e.TotalY}";
+                _startPosition = border.RenderTransform?.Value.GetPoint() ?? new Point(0, 0);
+                break;
+            case PanGestureStatus.Running:
+                label.Content = $"R: {_startPosition.X} + {e.TotalX}, {_startPosition.Y} + {e.TotalY}";
+                var transformOperation = TransformOperations.CreateBuilder(1);
+                transformOperation.AppendTranslate(_startPosition.X + e.TotalX, _startPosition.Y + e.TotalY);
+
+                border.SetValue(RenderTransformProperty, transformOperation.Build());
+                break;
+            case PanGestureStatus.Completed:
+                label.Content = $"C: {_startPosition.X} + {e.TotalX}, {_startPosition.Y} + {e.TotalY}";
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private void ReleasedOrange(object? sender, TapEventArgs e)
+    {
+        OrangeActionText.Content = $"Tap at {e.Position}";
+    }
+
+    private void PannedOrange(object? sender, PanUpdatedEventArgs e)
+    {
+        WritePan(OrangeActionText, Orange, e);
+    }
+}

--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
@@ -4,22 +4,26 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800"
              d:DesignHeight="450"
-             xmlns:swipeView="clr-namespace:Avalonia.Labs.Controls.SwipeView;assembly=Avalonia.Labs.Controls"
+             xmlns:labs="clr-namespace:Avalonia.Labs.Controls;assembly=Avalonia.Labs.Controls"
+             xmlns:base="clr-namespace:Avalonia.Labs.Controls.Base;assembly=Avalonia.Labs.Controls"
              x:Class="Avalonia.Labs.Catalog.Views.SwipeView">
   <ScrollViewer>
     <ItemsControl Items="{Binding Items}">
       <ItemsControl.ItemTemplate>
         <DataTemplate>
-          <swipeView:Swipe Margin="5">
-            <swipeView:Swipe.Content>
+          <labs:Swipe Margin="5">
+            <labs:Swipe.Content>
               <StackPanel Orientation="Horizontal" Spacing="5" Background="White">
+                <StackPanel.GestureRecognizers>
+                  <base:TapGestureRecognizer OnTap="TapGestureRecognizer_OnOnTap" />
+                </StackPanel.GestureRecognizers>
                 <Border Background="Red" Width="64" Height="64" />
                 <Border Background="Red" Width="64" Height="64" />
                 <Border Background="Red" Width="64" Height="64" />
-                <Label Content="You can swipe on the item" Foreground="Black"/>
+                <Label Content="You can swipe or click on the item" Foreground="Black"/>
               </StackPanel>
-            </swipeView:Swipe.Content>
-            <swipeView:Swipe.Right>
+            </labs:Swipe.Content>
+            <labs:Swipe.Right>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal" Spacing="5">
                   <Border Background="Blue" Width="64" Height="64" />
@@ -27,8 +31,8 @@
                   <Border Background="Blue" Width="64" Height="64" />
                 </StackPanel>
               </DataTemplate>
-            </swipeView:Swipe.Right>
-            <swipeView:Swipe.Left>
+            </labs:Swipe.Right>
+            <labs:Swipe.Left>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal" Spacing="5">
                   <Border Background="Green" Width="64" Height="64" />
@@ -36,8 +40,8 @@
                   <Border Background="Green" Width="64" Height="64" />
                 </StackPanel>
               </DataTemplate>
-            </swipeView:Swipe.Left>
-          </swipeView:Swipe>
+            </labs:Swipe.Left>
+          </labs:Swipe>
         </DataTemplate>
       </ItemsControl.ItemTemplate>
     </ItemsControl>

--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
@@ -1,0 +1,46 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800"
+             d:DesignHeight="450"
+             xmlns:swipeView="clr-namespace:Avalonia.Labs.Controls.SwipeView;assembly=Avalonia.Labs.Controls"
+             x:Class="Avalonia.Labs.Catalog.Views.SwipeView">
+  <ScrollViewer>
+    <ItemsControl Items="{Binding Items}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <swipeView:Swipe Margin="5">
+            <swipeView:Swipe.Content>
+              <StackPanel Orientation="Horizontal" Spacing="5" Background="White">
+                <Border Background="Red" Width="64" Height="64" />
+                <Border Background="Red" Width="64" Height="64" />
+                <Border Background="Red" Width="64" Height="64" />
+                <Label Content="You can swipe on the item" Foreground="Black"/>
+              </StackPanel>
+            </swipeView:Swipe.Content>
+            <swipeView:Swipe.Right>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                  <Border Background="Blue" Width="64" Height="64" />
+                  <Border Background="Blue" Width="64" Height="64" />
+                  <Border Background="Blue" Width="64" Height="64" />
+                </StackPanel>
+              </DataTemplate>
+            </swipeView:Swipe.Right>
+            <swipeView:Swipe.Left>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                  <Border Background="Green" Width="64" Height="64" />
+                  <Border Background="Green" Width="64" Height="64" />
+                  <Border Background="Green" Width="64" Height="64" />
+                </StackPanel>
+              </DataTemplate>
+            </swipeView:Swipe.Left>
+          </swipeView:Swipe>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </ScrollViewer>
+
+</UserControl>

--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Labs.Catalog.Views
+{
+    public partial class SwipeView : UserControl
+    {
+        public SwipeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Labs.Controls.Base;
 
 namespace Avalonia.Labs.Catalog.Views
 {
@@ -7,6 +9,15 @@ namespace Avalonia.Labs.Catalog.Views
         public SwipeView()
         {
             InitializeComponent();
+        }
+
+        private void TapGestureRecognizer_OnOnTap(object? sender, TapEventArgs e)
+        {
+            if (sender is StackPanel panel)
+            {
+                var label = panel.Children.OfType<Label>().First();
+                label.Content = "Clicked";
+            }
         }
     }
 }

--- a/samples/Avalonia.Labs.Catalog/Views/WelcomeView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/WelcomeView.axaml
@@ -63,6 +63,17 @@
                 <Label FontSize="18"
                        VerticalAlignment="Center">Async Image</Label>
             </Button>
+            <Button HorizontalAlignment="Stretch"
+                    Height="60"
+                    Command="{Binding NavigateTo}"
+                    CornerRadius="10"
+                    Margin="0,5">
+              <Button.CommandParameter>
+                <viewModels:SwipeViewModel/>
+              </Button.CommandParameter>
+              <Label FontSize="18"
+                     VerticalAlignment="Center">Swipe</Label>
+            </Button>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/samples/Avalonia.Labs.Catalog/Views/WelcomeView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/WelcomeView.axaml
@@ -74,6 +74,17 @@
               <Label FontSize="18"
                      VerticalAlignment="Center">Swipe</Label>
             </Button>
+          <Button HorizontalAlignment="Stretch"
+                  Height="60"
+                  Command="{Binding NavigateTo}"
+                  CornerRadius="10"
+                  Margin="0,5">
+            <Button.CommandParameter>
+              <viewModels:GestureViewModel/>
+            </Button.CommandParameter>
+            <Label FontSize="18"
+                   VerticalAlignment="Center">Gesture</Label>
+          </Button>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Avalonia.Labs.Controls/Base/MatrixExtensions.cs
+++ b/src/Avalonia.Labs.Controls/Base/MatrixExtensions.cs
@@ -1,0 +1,6 @@
+namespace Avalonia.Labs.Controls.Base;
+
+public static class MatrixExtensions
+{
+    public static Point GetPoint(this Matrix matrix, Point? point = null) => matrix.Transform(point ?? new Point(1, 1));
+}

--- a/src/Avalonia.Labs.Controls/Base/Pan/PanDirection.cs
+++ b/src/Avalonia.Labs.Controls/Base/Pan/PanDirection.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Avalonia.Labs.Controls.Base.Pan;
+
+/// <summary>
+/// Sets the pan directions
+/// </summary>
+[Flags]
+public enum PanDirection
+{
+    /// <summary>
+    /// Disables the pan
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// Allows pan to left
+    /// </summary>
+    Left = 1,
+    /// <summary>
+    /// Allows pan to right
+    /// </summary>
+    Right = 2,
+    /// <summary>
+    /// Allows pan up
+    /// </summary>
+    Up = 4,
+    /// <summary>
+    /// Allows pan down
+    /// </summary>
+    Down = 8,
+}

--- a/src/Avalonia.Labs.Controls/Base/Pan/PanGestureStatus.cs
+++ b/src/Avalonia.Labs.Controls/Base/Pan/PanGestureStatus.cs
@@ -1,0 +1,11 @@
+namespace Avalonia.Labs.Controls.Base.Pan;
+
+/// <summary>
+/// Indicates pan gesture status
+/// </summary>
+public enum PanGestureStatus
+{
+    Started,
+    Running,
+    Completed
+}

--- a/src/Avalonia.Labs.Controls/Base/Pan/PanUpdatedEventArgs.cs
+++ b/src/Avalonia.Labs.Controls/Base/Pan/PanUpdatedEventArgs.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Avalonia.Labs.Controls.Base.Pan;
+
+/// <summary>
+/// Contains the pan updates event data 
+/// </summary>
+public class PanUpdatedEventArgs : EventArgs
+{
+    public PanUpdatedEventArgs(PanGestureStatus statusType, double totalX, double totalY)
+    {
+        StatusType = statusType;
+        TotalX = totalX;
+        TotalY = totalY;
+    }
+
+    public PanGestureStatus StatusType { get; set; }
+    public double TotalX { get; set; }
+    public double TotalY { get; set; }
+}

--- a/src/Avalonia.Labs.Controls/Base/PanGestureRecongnizer.cs
+++ b/src/Avalonia.Labs.Controls/Base/PanGestureRecongnizer.cs
@@ -4,6 +4,9 @@ using Avalonia.Input.GestureRecognizers;
 
 namespace Avalonia.Labs.Controls.Base;
 
+/// <summary>
+/// Indicates pan gesture status
+/// </summary>
 public enum PanGestureStatus
 {
     Started,
@@ -11,16 +14,37 @@ public enum PanGestureStatus
     Completed
 }
 
+/// <summary>
+/// Sets the pan directions
+/// </summary>
 [Flags]
 public enum PanDirection
 {
+    /// <summary>
+    /// Disables the pan
+    /// </summary>
     None = 0,
+    /// <summary>
+    /// Allows pan to left
+    /// </summary>
     Left = 1,
+    /// <summary>
+    /// Allows pan to right
+    /// </summary>
     Right = 2,
+    /// <summary>
+    /// Allows pan up
+    /// </summary>
     Up = 4,
+    /// <summary>
+    /// Allows pan down
+    /// </summary>
     Down = 8,
 }
 
+/// <summary>
+/// Contains the pan updates event data 
+/// </summary>
 public class PanUpdatedEventArgs : EventArgs
 {
     public PanUpdatedEventArgs(PanGestureStatus statusType, double totalX, double totalY)
@@ -35,6 +59,9 @@ public class PanUpdatedEventArgs : EventArgs
     public double TotalY { get; set; }
 }
 
+/// <summary>
+/// The gesture recognizer for pan gesture 
+/// </summary>
 public class PanGestureRecognizer : IGestureRecognizer
 {
     private IInputElement? _inputElement;
@@ -52,6 +79,7 @@ public class PanGestureRecognizer : IGestureRecognizer
 
     public float Threshold { get; set; } = 5;
 
+    /// <inheritdoc />
     public void Initialize(IInputElement target, IGestureRecognizerActionsDispatcher actions)
     {
         _inputElement = target;
@@ -60,6 +88,7 @@ public class PanGestureRecognizer : IGestureRecognizer
         _state = PanGestureStatus.Completed;
     }
 
+    /// <inheritdoc />
     public void PointerPressed(PointerPressedEventArgs e)
     {
         _startPosition = e.GetPosition(_parent);
@@ -67,6 +96,7 @@ public class PanGestureRecognizer : IGestureRecognizer
         OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Started, 0, 0));
     }
 
+    /// <inheritdoc />
     public void PointerMoved(PointerEventArgs e)
     {
         if (!_startPosition.HasValue)
@@ -117,6 +147,7 @@ public class PanGestureRecognizer : IGestureRecognizer
         OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Running, _delta.X, _delta.Y));
     }
 
+    /// <inheritdoc />
     public void PointerReleased(PointerReleasedEventArgs e)
     {
         if (!_startPosition.HasValue || _state == PanGestureStatus.Completed)
@@ -134,15 +165,19 @@ public class PanGestureRecognizer : IGestureRecognizer
         _lastPosition = null;
     }
 
+    /// <inheritdoc />
     public void PointerCaptureLost(IPointer pointer)
     {
         if (!_startPosition.HasValue || _state == PanGestureStatus.Completed)
         {
             return;
         }
-    
-        OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(
-            PanGestureStatus.Completed, _delta.X, _delta.Y));
+
+        OnPan?.Invoke(_inputElement,
+            new PanUpdatedEventArgs(
+                PanGestureStatus.Completed,
+                _delta.X,
+                _delta.Y));
 
         _startPosition = null;
         _lastPosition = null;

--- a/src/Avalonia.Labs.Controls/Base/PanGestureRecongnizer.cs
+++ b/src/Avalonia.Labs.Controls/Base/PanGestureRecongnizer.cs
@@ -1,0 +1,151 @@
+using System;
+using Avalonia.Input;
+using Avalonia.Input.GestureRecognizers;
+
+namespace Avalonia.Labs.Controls.Base;
+
+public enum PanGestureStatus
+{
+    Started,
+    Running,
+    Completed
+}
+
+[Flags]
+public enum PanDirection
+{
+    None = 0,
+    Left = 1,
+    Right = 2,
+    Up = 4,
+    Down = 8,
+}
+
+public class PanUpdatedEventArgs : EventArgs
+{
+    public PanUpdatedEventArgs(PanGestureStatus statusType, double totalX, double totalY)
+    {
+        StatusType = statusType;
+        TotalX = totalX;
+        TotalY = totalY;
+    }
+
+    public PanGestureStatus StatusType { get; set; }
+    public double TotalX { get; set; }
+    public double TotalY { get; set; }
+}
+
+public class PanGestureRecognizer : IGestureRecognizer
+{
+    private IInputElement? _inputElement;
+    private Point? _startPosition;
+    private Point? _lastPosition;
+    private Point _delta;
+    private PanGestureStatus _state;
+    private Visual? _visual;
+    private Visual? _parent;
+
+    public event EventHandler<PanUpdatedEventArgs>? OnPan;
+
+    public PanDirection Direction { get; set; } =
+        PanDirection.Left | PanDirection.Right | PanDirection.Up | PanDirection.Down;
+
+    public float Threshold { get; set; } = 5;
+
+    public void Initialize(IInputElement target, IGestureRecognizerActionsDispatcher actions)
+    {
+        _inputElement = target;
+        _visual = target as Visual;
+        _parent = _visual?.Parent as Visual;
+        _state = PanGestureStatus.Completed;
+    }
+
+    public void PointerPressed(PointerPressedEventArgs e)
+    {
+        _startPosition = e.GetPosition(_parent);
+        _state = PanGestureStatus.Started;
+        OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Started, 0, 0));
+    }
+
+    public void PointerMoved(PointerEventArgs e)
+    {
+        if (!_startPosition.HasValue)
+        {
+            return;
+        }
+
+        _state = PanGestureStatus.Running;
+        _lastPosition = e.GetPosition(_parent);
+        _delta = _lastPosition.Value - _startPosition.Value;
+
+        var currentDirection = PanDirection.None;
+        if (_delta.X < -Threshold)
+        {
+            currentDirection |= PanDirection.Left;
+        }
+        else if (_delta.X > Threshold)
+        {
+            currentDirection |= PanDirection.Right;
+        }
+
+        if (_delta.Y < -Threshold)
+        {
+            currentDirection |= PanDirection.Up;
+        }
+        else if (_delta.Y > Threshold)
+        {
+            currentDirection |= PanDirection.Down;
+        }
+
+        if ((currentDirection & Direction) == 0)
+        {
+            return;
+        }
+
+        if (e.Pointer.Captured == null)
+        {
+            e.Pointer.Capture(_inputElement);
+        }
+
+        if ((Math.Abs(_delta.X) > Threshold || Math.Abs(_delta.Y) > Threshold) && e.Pointer.Captured == null)
+        {
+            _startPosition = null;
+            _lastPosition = null;
+            return;
+        }
+
+        OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Running, _delta.X, _delta.Y));
+    }
+
+    public void PointerReleased(PointerReleasedEventArgs e)
+    {
+        if (!_startPosition.HasValue || _state == PanGestureStatus.Completed)
+        {
+            return;
+        }
+
+        _state = PanGestureStatus.Completed;
+        var currentPosition = e.GetPosition(_parent);
+        var delta = currentPosition - _startPosition.Value;
+        OnPan?.Invoke(_inputElement,
+            new PanUpdatedEventArgs(PanGestureStatus.Completed, delta.X, delta.Y));
+
+        _startPosition = null;
+        _lastPosition = null;
+    }
+
+    public void PointerCaptureLost(IPointer pointer)
+    {
+        if (!_startPosition.HasValue || _state == PanGestureStatus.Completed)
+        {
+            return;
+        }
+    
+        OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(
+            PanGestureStatus.Completed, _delta.X, _delta.Y));
+
+        _startPosition = null;
+        _lastPosition = null;
+        _delta = default;
+    }
+}

--- a/src/Avalonia.Labs.Controls/Base/Tap/TapEventArgs.cs
+++ b/src/Avalonia.Labs.Controls/Base/Tap/TapEventArgs.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Avalonia.Labs.Controls.Base;
+
+/// <summary>
+/// Contains the tap event data 
+/// </summary>
+public class TapEventArgs : EventArgs
+{
+    public TapEventArgs(Point position)
+    {
+        Position = position;
+    }
+
+    public Point Position
+    {
+        get;
+        set;
+    }
+}

--- a/src/Avalonia.Labs.Controls/Base/Tap/TapGestureRecognizer.cs
+++ b/src/Avalonia.Labs.Controls/Base/Tap/TapGestureRecognizer.cs
@@ -1,0 +1,73 @@
+using System;
+using Avalonia.Input;
+using Avalonia.Input.GestureRecognizers;
+
+namespace Avalonia.Labs.Controls.Base;
+
+public enum DetectOn
+{
+    PointerPressed,
+    PointerReleased
+}
+
+public class TapGestureRecognizer : IGestureRecognizer
+{
+    private IInputElement? _inputElement;
+    private Visual? _visual;
+    private Visual? _parent;
+    private Point? _startPosition;
+
+    public float Threshold { get; set; } = 5;
+    
+    public DetectOn DetectOn { get; set; } = DetectOn.PointerReleased;
+    
+    public event EventHandler<TapEventArgs>? OnTap;
+    
+    public void Initialize(IInputElement target, IGestureRecognizerActionsDispatcher actions)
+    {
+        _inputElement = target;
+        _visual = target as Visual;
+        _parent = _visual?.Parent as Visual;
+    }
+
+    public void PointerPressed(PointerPressedEventArgs e)
+    {
+        _startPosition = e.GetPosition(_parent);
+        if (DetectOn == DetectOn.PointerPressed)
+        {
+            OnTap?.Invoke(_inputElement, new TapEventArgs(_startPosition.Value));
+            _startPosition = null;
+            e.Handled = true;
+        }
+    }
+
+    public void PointerReleased(PointerReleasedEventArgs e)
+    {
+        if (DetectOn != DetectOn.PointerReleased)
+        {
+            return;
+        }
+        
+        if (!_startPosition.HasValue)
+        {
+            return;
+        }
+        
+        var lastPosition = e.GetPosition(_parent);
+        var delta = lastPosition - _startPosition.Value;
+        if (Math.Abs(delta.X) < Threshold && Math.Abs(delta.Y) < Threshold)
+        {
+            OnTap?.Invoke(_inputElement, new TapEventArgs(lastPosition));
+            e.Handled = true;
+        }
+    }
+
+    public void PointerMoved(PointerEventArgs e)
+    {
+    }
+
+    public void PointerCaptureLost(IPointer pointer)
+    {
+        _startPosition = null;
+    }
+}

--- a/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
@@ -127,12 +127,7 @@ public class Swipe : Grid
 
     private SwipeState CalculateState(double translationX)
     {
-        if (!_rightContainer.IsVisible && !_leftContainer.IsVisible)
-        {
-            return SwipeState.Hidden;
-        }
-
-        var stepSize = _rightContainer.IsVisible
+        var stepSize = translationX < 0
             ? _rightContainer.Bounds.Width
             : _leftContainer.Bounds.Width;
 
@@ -209,8 +204,16 @@ public class Swipe : Grid
                 var x = _initialX + e.TotalX;
 
                 SetTranslate(x);
-                _rightContainer.IsVisible = x < 0;
-                _leftContainer.IsVisible = x > 0;
+
+                if (!_rightContainer.IsVisible)
+                {
+                    _rightContainer.IsVisible = x < 0;
+                }
+
+                if (!_leftContainer.IsVisible)
+                {
+                    _leftContainer.IsVisible = x > 0;
+                }
                 break;
             case PanGestureStatus.Completed:
                 _bodyContainer.Transitions!.Add(_transition);

--- a/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Threading;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Labs.Controls.Base;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Media.Transformation;
+
+namespace Avalonia.Labs.Controls.SwipeView;
+
+public class Swipe : Grid
+{
+    public static readonly StyledProperty<DataTemplate> RightTemplateProperty =
+        AvaloniaProperty.Register<Swipe, DataTemplate>(nameof(Right));
+
+    /// <summary>
+    /// DataTemplate for the right side
+    /// </summary>
+    public DataTemplate Right
+    {
+        get => GetValue(RightTemplateProperty);
+        set => SetValue(RightTemplateProperty, value);
+    }
+
+    public static readonly StyledProperty<DataTemplate> LeftTemplateProperty =
+        AvaloniaProperty.Register<Swipe, DataTemplate>(nameof(Left));
+
+    /// <summary>
+    /// DataTemplate for the left side
+    /// </summary>
+    public DataTemplate Left
+    {
+        get => GetValue(LeftTemplateProperty);
+        set => SetValue(LeftTemplateProperty, value);
+    }
+
+    public static readonly StyledProperty<Control> ContentProperty =
+        AvaloniaProperty.Register<Swipe, Control>(nameof(Content));
+
+    /// <summary>
+    /// The content of the Swipe component
+    /// </summary>
+    public Control Content
+    {
+        get => GetValue(ContentProperty);
+        set => SetValue(ContentProperty, value);
+    }
+
+    public static readonly StyledProperty<SwipeState> SwipeStateProperty =
+        AvaloniaProperty.Register<Swipe, SwipeState>(nameof(SwipeState));
+
+    /// <summary>
+    /// The current state of the Swipe component
+    /// </summary>
+    public SwipeState SwipeState
+    {
+        get => GetValue(SwipeStateProperty);
+        set => SetValue(SwipeStateProperty, value);
+    }
+
+    public Swipe()
+    {
+        _rightContainer = new ContentPresenter
+        {
+            IsVisible = false, HorizontalAlignment = HorizontalAlignment.Right
+        };
+
+        _leftContainer = new ContentPresenter
+        {
+            IsVisible = false, HorizontalAlignment = HorizontalAlignment.Left
+        };
+
+        _bodyContainer = new ContentPresenter
+        {
+            Transitions = new Transitions()
+        };
+
+        _transition = new TransformOperationsTransition
+        {
+            Property = RenderTransformProperty, 
+            Duration = TimeSpan.FromMilliseconds(200),
+            Easing = new CubicEaseOut()
+        };
+        
+        var panGestureRecognizer = new PanGestureRecognizer
+        {
+            Direction = PanDirection.Left | PanDirection.Right, Threshold = 10,
+        };
+
+        panGestureRecognizer.OnPan += PanUpdated;
+
+        _bodyContainer.GestureRecognizers.Add(panGestureRecognizer);
+
+        Children.Add(_rightContainer);
+        Children.Add(_leftContainer);
+        Children.Add(_bodyContainer);
+    }
+
+    private readonly ContentPresenter _rightContainer;
+    private readonly ContentPresenter _leftContainer;
+    private readonly ContentPresenter _bodyContainer;
+    private readonly TransformOperationsTransition _transition;
+
+    private double _initialX;
+    private double _currentX;
+    private CancellationTokenSource? _tokenSource;
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (nameof(Content) == e.Property.Name)
+        {
+            _bodyContainer.Content = e.NewValue;
+            return;
+        }
+
+        if (nameof(SwipeState) == e.Property.Name)
+        {
+            ProcessSwipe(SwipeState);
+        }
+    }
+
+    private SwipeState CalculateState(double translationX)
+    {
+        if (!_rightContainer.IsVisible && !_leftContainer.IsVisible)
+        {
+            return SwipeState.Hidden;
+        }
+
+        var stepSize = _rightContainer.IsVisible
+            ? _rightContainer.Bounds.Width
+            : _leftContainer.Bounds.Width;
+
+        if (stepSize > Math.Abs(translationX))
+        {
+            return SwipeState.Hidden;
+        }
+
+        return translationX switch
+        {
+            < 0 => SwipeState.RightVisible,
+            > 0 => SwipeState.LeftVisible,
+            _ => SwipeState.Hidden
+        };
+    }
+
+    private void ProcessSwipe(SwipeState state)
+    {
+        _tokenSource?.Cancel();
+        _tokenSource = new CancellationTokenSource();
+        switch (state)
+        {
+            case SwipeState.RightVisible:
+                _rightContainer.IsVisible = true;
+                MaterializeDataTemplate(_rightContainer, Right);
+                SetTranslate(-_rightContainer.Bounds.Width);
+
+                break;
+            case SwipeState.LeftVisible:
+                _leftContainer.IsVisible = true;
+                MaterializeDataTemplate(_leftContainer, Left);
+                SetTranslate(_leftContainer.Bounds.Width);
+
+                break;
+            case SwipeState.Hidden:
+            default:
+                SetTranslate(0);
+                break;
+        }
+    }
+
+    private void SetTranslate(double x)
+    {
+        _currentX = x;
+        var transformOperation = TransformOperations.CreateBuilder(1);
+        transformOperation.AppendTranslate(x, 0);
+
+        _bodyContainer.SetValue(RenderTransformProperty, transformOperation.Build());
+    }
+
+    private void MaterializeDataTemplate(ContentPresenter contentView, DataTemplate? dataTemplate)
+    {
+        if (contentView.Content is not null || dataTemplate is null)
+        {
+            return;
+        }
+
+        var view = dataTemplate.Build(DataContext);
+        contentView.Content = view;
+    }
+
+    private void PanUpdated(object? sender, PanUpdatedEventArgs e)
+    {
+        switch (e.StatusType)
+        {
+            case PanGestureStatus.Started:
+                _initialX = _currentX;
+                _bodyContainer.Transitions!.Remove(_transition);
+                MaterializeDataTemplate(_rightContainer, Right);
+                MaterializeDataTemplate(_leftContainer, Left);
+
+                break;
+            case PanGestureStatus.Running:
+                var x = _initialX + e.TotalX;
+
+                SetTranslate(x);
+                _rightContainer.IsVisible = x < 0;
+                _leftContainer.IsVisible = x > 0;
+                break;
+            case PanGestureStatus.Completed:
+                _bodyContainer.Transitions!.Add(_transition);
+                var newState = CalculateState(_initialX + e.TotalX);
+                if (SwipeState == newState)
+                {
+                    ProcessSwipe(newState);
+                    return;
+                }
+
+                SwipeState = newState;
+                break;
+        }
+    }
+}

--- a/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Windows.Input;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
@@ -69,9 +67,6 @@ public class Swipe : Grid
 
     private double _initialX;
     private double _currentX;
-    private CancellationTokenSource? _tokenSource;
-    private ICommand? _command;
-    private object? _commandParameter;
 
     public Swipe()
     {
@@ -149,8 +144,6 @@ public class Swipe : Grid
 
     private void ProcessSwipe(SwipeState state)
     {
-        _tokenSource?.Cancel();
-        _tokenSource = new CancellationTokenSource();
         switch (state)
         {
             case SwipeState.RightVisible:

--- a/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Threading;
+using System.Windows.Input;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
-using Avalonia.Labs.Controls.Base;
+using Avalonia.Labs.Controls.Base.Pan;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media.Transformation;
 
-namespace Avalonia.Labs.Controls.SwipeView;
+namespace Avalonia.Labs.Controls;
 
 public class Swipe : Grid
 {
@@ -61,6 +62,17 @@ public class Swipe : Grid
         set => SetValue(SwipeStateProperty, value);
     }
 
+    private readonly ContentPresenter _rightContainer;
+    private readonly ContentPresenter _leftContainer;
+    private readonly ContentPresenter _bodyContainer;
+    private readonly TransformOperationsTransition _transition;
+
+    private double _initialX;
+    private double _currentX;
+    private CancellationTokenSource? _tokenSource;
+    private ICommand? _command;
+    private object? _commandParameter;
+
     public Swipe()
     {
         _rightContainer = new ContentPresenter
@@ -80,11 +92,11 @@ public class Swipe : Grid
 
         _transition = new TransformOperationsTransition
         {
-            Property = RenderTransformProperty, 
+            Property = RenderTransformProperty,
             Duration = TimeSpan.FromMilliseconds(200),
             Easing = new CubicEaseOut()
         };
-        
+
         var panGestureRecognizer = new PanGestureRecognizer
         {
             Direction = PanDirection.Left | PanDirection.Right, Threshold = 10,
@@ -98,15 +110,6 @@ public class Swipe : Grid
         Children.Add(_leftContainer);
         Children.Add(_bodyContainer);
     }
-
-    private readonly ContentPresenter _rightContainer;
-    private readonly ContentPresenter _leftContainer;
-    private readonly ContentPresenter _bodyContainer;
-    private readonly TransformOperationsTransition _transition;
-
-    private double _initialX;
-    private double _currentX;
-    private CancellationTokenSource? _tokenSource;
 
     /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
@@ -205,15 +208,8 @@ public class Swipe : Grid
 
                 SetTranslate(x);
 
-                if (!_rightContainer.IsVisible)
-                {
-                    _rightContainer.IsVisible = x < 0;
-                }
-
-                if (!_leftContainer.IsVisible)
-                {
-                    _leftContainer.IsVisible = x > 0;
-                }
+                _rightContainer.IsVisible = x < 0;
+                _leftContainer.IsVisible = x > 0;
                 break;
             case PanGestureStatus.Completed:
                 _bodyContainer.Transitions!.Add(_transition);

--- a/src/Avalonia.Labs.Controls/SwipeView/SwipeState.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/SwipeState.cs
@@ -1,0 +1,21 @@
+namespace Avalonia.Labs.Controls.SwipeView;
+
+/// <summary>
+/// Holds the possible states of the Swipe component
+/// </summary>
+public enum SwipeState
+{
+    /// <summary>
+    /// Means that the right side is visible
+    /// </summary>
+    RightVisible,
+    
+    /// <summary>
+    /// Means that the left side is visible
+    /// </summary>
+    LeftVisible,
+    /// <summary>
+    /// Means that all sides are hidden
+    /// </summary>
+    Hidden
+}

--- a/src/Avalonia.Labs.Controls/SwipeView/SwipeState.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/SwipeState.cs
@@ -1,4 +1,4 @@
-namespace Avalonia.Labs.Controls.SwipeView;
+namespace Avalonia.Labs.Controls;
 
 /// <summary>
 /// Holds the possible states of the Swipe component


### PR DESCRIPTION
This pull request adds the `` Swipe `` control that works with mobile scrolling as expected. Basically, you can add it and have the ability to swipe left and right to show items under it. Also, it has two new gesture recognizers, `` PanGestureRecognizer `` and `` TapGestureRecognizer ``, which are utilized to make the `` Swipe `` control work.

You can have a look at the demo in the attached video:
https://user-images.githubusercontent.com/5927686/226204800-5de3ca40-076d-4624-8f7b-54c0f7e5ab5f.mp4

