### PR TITLE
fix(Swipe): Missing set Visibility of Left and Right container when set SwipeState to Hidden

### DIFF
--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml
@@ -13,14 +13,14 @@
         <DataTemplate>
           <labs:Swipe Margin="5">
             <labs:Swipe.Content>
-              <StackPanel Orientation="Horizontal" Spacing="5" Background="White">
+              <StackPanel Orientation="Horizontal" Spacing="5" Background="Transparent">
                 <StackPanel.GestureRecognizers>
                   <base:TapGestureRecognizer OnTap="TapGestureRecognizer_OnOnTap" />
                 </StackPanel.GestureRecognizers>
                 <Border Background="Red" Width="64" Height="64" />
                 <Border Background="Red" Width="64" Height="64" />
                 <Border Background="Red" Width="64" Height="64" />
-                <Label Content="You can swipe or click on the item" Foreground="Black"/>
+                <Label Content="You can swipe or click on the item"/>
               </StackPanel>
             </labs:Swipe.Content>
             <labs:Swipe.Right>
@@ -28,14 +28,14 @@
                 <StackPanel Orientation="Horizontal" Spacing="5">
                   <Border Background="Blue" Width="64" Height="64" />
                   <Border Background="Blue" Width="64" Height="64" />
-                  <Border Background="Blue" Width="64" Height="64" />
+                  <Button Classes="accent" Width="64" Height="64" Click="CloseSwipe" Content="Close" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
                 </StackPanel>
               </DataTemplate>
             </labs:Swipe.Right>
             <labs:Swipe.Left>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal" Spacing="5">
-                  <Border Background="Green" Width="64" Height="64" />
+                  <Button Classes="accent" Width="64" Height="64" Click="CloseSwipe" Content="Close" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
                   <Border Background="Green" Width="64" Height="64" />
                   <Border Background="Green" Width="64" Height="64" />
                 </StackPanel>

--- a/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/SwipeView.axaml.cs
@@ -1,6 +1,10 @@
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Labs.Controls;
 using Avalonia.Labs.Controls.Base;
+using Avalonia.Visuals;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Labs.Catalog.Views
 {
@@ -17,6 +21,14 @@ namespace Avalonia.Labs.Catalog.Views
             {
                 var label = panel.Children.OfType<Label>().First();
                 label.Content = "Clicked";
+            }
+        }
+
+        private void CloseSwipe(object? sender, RoutedEventArgs e)
+        {
+            if (sender is Button button && button.GetVisualAncestors().OfType<Swipe>().FirstOrDefault() is Labs.Controls.Swipe swipe)
+            {
+                swipe.SwipeState = SwipeState.Hidden;
             }
         }
     }

--- a/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Labs.Controls/SwipeView/Swipe.cs
@@ -172,6 +172,8 @@ public class Swipe : Grid
         transformOperation.AppendTranslate(x, 0);
 
         _bodyContainer.SetValue(RenderTransformProperty, transformOperation.Build());
+        _rightContainer.IsVisible = x < 0;
+        _leftContainer.IsVisible = x > 0;
     }
 
     private void MaterializeDataTemplate(ContentPresenter contentView, DataTemplate? dataTemplate)
@@ -201,8 +203,7 @@ public class Swipe : Grid
 
                 SetTranslate(x);
 
-                _rightContainer.IsVisible = x < 0;
-                _leftContainer.IsVisible = x > 0;
+
                 break;
             case PanGestureStatus.Completed:
                 _bodyContainer.Transitions!.Add(_transition);


### PR DESCRIPTION
### Before
![Before](https://github.com/AvaloniaUI/Avalonia.Labs/assets/12531229/904aba49-a325-42fc-8f81-48990cc2e16b)

### After

![After](https://github.com/AvaloniaUI/Avalonia.Labs/assets/12531229/94402356-adf6-4612-8950-04a566571564)

- Updated example of how to close Swipe control from code
- Updated Swipe sample to work with dark theme
- fix 