### PR TITLE
Use latest avalonia release in samples, fix android configuration change issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
+    <AvaloniaSampleVersion>11.0.4</AvaloniaSampleVersion>
     <SkiaSharpVersion>2.88.3</SkiaSharpVersion>
     <AvaloniaPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1bba1142285fe0419326fb25866ba62c47e6c2b5c1ab0c95b46413fad375471232cb81706932e1cef38781b9ebd39d5100401bacb651c6c5bbf59e571e81b3bc08d2a622004e08b1a6ece82a7e0b9857525c86d2b95fab4bc3dce148558d7f3ae61aa3a234086902aeface87d9dfdd32b9d2fe3c6dd4055b5ab4b104998bd87</AvaloniaPublicKey>
   </PropertyGroup>

--- a/samples/Avalonia.Labs.Catalog.Android/Avalonia.Labs.Catalog.Android.csproj
+++ b/samples/Avalonia.Labs.Catalog.Android/Avalonia.Labs.Catalog.Android.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Android" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Avalonia.Labs.Catalog.Android/MainActivity.cs
+++ b/samples/Avalonia.Labs.Catalog.Android/MainActivity.cs
@@ -5,7 +5,7 @@ using Avalonia.ReactiveUI;
 
 namespace Avalonia.Labs.Catalog.Android;
 
-[Activity(Label = "Avalonia.Labs.Catalog.Android", Theme = "@style/MyTheme.NoActionBar", Icon = "@drawable/icon", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+[Activity(Label = "Avalonia.Labs.Catalog.Android", Theme = "@style/MyTheme.NoActionBar", Icon = "@drawable/icon", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity<App>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)

--- a/samples/Avalonia.Labs.Catalog.Desktop/Avalonia.Labs.Catalog.Desktop.csproj
+++ b/samples/Avalonia.Labs.Catalog.Desktop/Avalonia.Labs.Catalog.Desktop.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSampleVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Avalonia.Labs.Catalog.Web/Avalonia.Labs.Catalog.Web.csproj
+++ b/samples/Avalonia.Labs.Catalog.Web/Avalonia.Labs.Catalog.Web.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Browser" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Avalonia.Labs.Catalog.iOS/Avalonia.Labs.Catalog.iOS.csproj
+++ b/samples/Avalonia.Labs.Catalog.iOS/Avalonia.Labs.Catalog.iOS.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.iOS" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.iOS" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Avalonia.Labs.Catalog/Avalonia.Labs.Catalog.csproj
+++ b/samples/Avalonia.Labs.Catalog/Avalonia.Labs.Catalog.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaSampleVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Avalonia.Labs.Catalog/Views/MainView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/MainView.axaml.cs
@@ -23,6 +23,11 @@ public partial class MainView : UserControl
         }
     }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+    }
+
     private async void TopLevel_BackRequested(object? sender, Interactivity.RoutedEventArgs e)
     {
         var viewModel = DataContext as MainViewModel;

--- a/samples/Avalonia.Labs.Controls.Samples/Avalonia.Labs.Controls.Samples.csproj
+++ b/samples/Avalonia.Labs.Controls.Samples/Avalonia.Labs.Controls.Samples.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSampleVersion)" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaSampleVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update the samples projects to use avalonia 11.0.4. The library projects are kept on 11.0.0. 
Also fixes https://github.com/AvaloniaUI/Avalonia/issues/13151 by handling UiMode configuration change on the activity.