### PR TITLE
Fix Lottie loading again after unloaded

### DIFF
--- a/src/Avalonia.Labs.Lottie/Lottie.cs
+++ b/src/Avalonia.Labs.Lottie/Lottie.cs
@@ -20,7 +20,6 @@ public class Lottie : Control
     private SkiaSharp.Skottie.Animation? _animation;
     private int _repeatCount;
     private readonly Uri _baseUri;
-    private string? _preloadPath;
     private CompositionCustomVisual? _customVisual;
 
     /// <summary>
@@ -126,13 +125,14 @@ public class Lottie : Control
 
         LayoutUpdated += OnLayoutUpdated;
 
-        if (_preloadPath is null)
+        string? path = Path;
+        if (path is null)
         {
             return;
         }
 
         DisposeImpl();
-        Load(_preloadPath);
+        Load(path);
 
         _customVisual.Size = new Vector2((float)Bounds.Size.Width, (float)Bounds.Size.Height);
         _customVisual.SendHandlerMessage(
@@ -211,14 +211,12 @@ public class Lottie : Control
         {
             case nameof(Path):
             {
-                var path = change.GetNewValue<string?>();
-
-                _preloadPath = path;
                 if (_customVisual is null)
                 {
                     return;
                 }
 
+                var path = change.GetNewValue<string?>();
                 Load(path);
                 break;
             }
@@ -329,6 +327,5 @@ public class Lottie : Control
     private void DisposeImpl()
     {
         _customVisual?.SendHandlerMessage(new LottiePayload(LottieCommand.Dispose));
-        _animation = null;
     }
 }

--- a/src/Avalonia.Labs.Lottie/Lottie.cs
+++ b/src/Avalonia.Labs.Lottie/Lottie.cs
@@ -143,7 +143,6 @@ public class Lottie : Control
                 StretchDirection));
         
         Start();
-        _preloadPath = null;
     }
 
     protected override void OnUnloaded(RoutedEventArgs e)
@@ -154,6 +153,8 @@ public class Lottie : Control
 
         Stop();
         DisposeImpl();
+        _animation = null;
+        _customVisual = null;
     }
 
     private void OnLayoutUpdated(object? sender, EventArgs e)
@@ -212,9 +213,9 @@ public class Lottie : Control
             {
                 var path = change.GetNewValue<string?>();
 
-                if (_preloadPath is null && _customVisual is null)
+                _preloadPath = path;
+                if (_customVisual is null)
                 {
-                    _preloadPath = path;
                     return;
                 }
 


### PR DESCRIPTION
This fixes issue https://github.com/AvaloniaUI/Avalonia.Labs/issues/26 where an exception would occur after the Lottie control is unloaded and then loaded again.

"_animation" and "_customVisual" are now set to null in OnUnloaded. Setting "_animation" to null fixes the exception. Setting "_customVisual" to null allows it to be used as the sole indicator of whether the control is loaded (previously this was being used in combination with "_preloadPath"). The "_preloadPath" variable has been removed as it was unnecessary and could potentially cause issues if the Path property was set multiple times before the control is loaded. Changing the Path property works the same as before. It will load the new animation if the control is already loaded, or return if the control is not loaded. The Path property is read when it is required in OnLoaded.