### PR TITLE
FlexPanel enhancements (grow, shrink, basis, fixes)

### DIFF
--- a/samples/Avalonia.Labs.Catalog/ViewModels/FlexItemViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/FlexItemViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reactive.Linq;
 
 using Avalonia.Labs.Panels;
-
+using Avalonia.Layout;
 using ReactiveUI;
 
 namespace Avalonia.Labs.Catalog.ViewModels
@@ -19,6 +19,10 @@ namespace Avalonia.Labs.Catalog.ViewModels
         private int _order;
         private double _shrink = 1.0;
         private double _grow;
+        private double _basisValue = 100.0;
+        private FlexBasisKind _basisKind;
+        private HorizontalAlignment _horizontalAlignment;
+        private VerticalAlignment _verticalAlignment; 
 
         public FlexItemViewModel(int value)
         {
@@ -66,6 +70,40 @@ namespace Avalonia.Labs.Catalog.ViewModels
         {
             get => _grow;
             set => this.RaiseAndSetIfChanged(ref _grow, value);
+        }
+
+        public double BasisValue
+        {
+            get => _basisValue;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _basisValue, value);
+                this.RaisePropertyChanged(nameof(Basis));
+            }
+        }
+
+        public FlexBasisKind BasisKind
+        {
+            get => _basisKind;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _basisKind, value);
+                this.RaisePropertyChanged(nameof(Basis));
+            }
+        }
+
+        public FlexBasis Basis => new(_basisValue, _basisKind);
+
+        public HorizontalAlignment HorizontalAlignment
+        {
+            get => _horizontalAlignment;
+            set => this.RaiseAndSetIfChanged(ref _horizontalAlignment, value);
+        }
+
+        public VerticalAlignment VerticalAlignment
+        {
+            get => _verticalAlignment;
+            set => this.RaiseAndSetIfChanged(ref _verticalAlignment, value);
         }
     }
 }

--- a/samples/Avalonia.Labs.Catalog/ViewModels/FlexItemViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/FlexItemViewModel.cs
@@ -17,6 +17,8 @@ namespace Avalonia.Labs.Catalog.ViewModels
 
         private AlignItems _alignSelfItem = AlignSelfAuto;
         private int _order;
+        private double _shrink = 1.0;
+        private double _grow;
 
         public FlexItemViewModel(int value)
         {
@@ -52,6 +54,18 @@ namespace Avalonia.Labs.Catalog.ViewModels
         {
             get => _order;
             set => this.RaiseAndSetIfChanged(ref _order, value);
+        }
+
+        public double Shrink
+        {
+            get => _shrink;
+            set => this.RaiseAndSetIfChanged(ref _shrink, value);
+        }
+
+        public double Grow
+        {
+            get => _grow;
+            set => this.RaiseAndSetIfChanged(ref _grow, value);
         }
     }
 }

--- a/samples/Avalonia.Labs.Catalog/ViewModels/FlexViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/FlexViewModel.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 
 using Avalonia.Labs.Catalog.Views;
 using Avalonia.Labs.Panels;
-
+using Avalonia.Layout;
 using ReactiveUI;
 
 namespace Avalonia.Labs.Catalog.ViewModels
@@ -22,7 +22,7 @@ namespace Avalonia.Labs.Catalog.ViewModels
         private AlignContent _alignContent = AlignContent.FlexStart;
         private FlexWrap _wrap = FlexWrap.Wrap;
 
-        private int _columnSpacing = 8;
+        private int _columnSpacing = 64;
         private int _rowSpacing = 32;
 
         private int _currentNumber = 41;
@@ -55,6 +55,12 @@ namespace Avalonia.Labs.Catalog.ViewModels
         public IEnumerable AlignContentValues { get; } = Enum.GetValues(typeof(AlignContent));
 
         public IEnumerable WrapValues { get; } = Enum.GetValues(typeof(FlexWrap));
+
+        public IEnumerable FlexBasisKindValues { get; } = Enum.GetValues(typeof(FlexBasisKind));
+
+        public IEnumerable HorizontalAlignmentValues { get; } = Enum.GetValues(typeof(HorizontalAlignment));
+
+        public IEnumerable VerticalAlignmentValues { get; } = Enum.GetValues(typeof(VerticalAlignment));
 
         public IEnumerable AlignSelfValues { get; } = Enum.GetValues(typeof(AlignItems)).Cast<AlignItems>().Prepend(FlexItemViewModel.AlignSelfAuto);
         

--- a/samples/Avalonia.Labs.Catalog/Views/FlexView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/FlexView.axaml
@@ -21,7 +21,7 @@
                    Gestures.Tapped="OnItemTapped">
         <ListBoxItem.Styles>
           <Style Selector="ListBoxItem">
-            <Setter Property="Background" Value="LightBlue" />
+            <Setter Property="Background" Value="#228" />
           </Style>
           <Style Selector="ListBoxItem:selected">
             <Setter Property="Background" Value="DodgerBlue" />
@@ -126,6 +126,20 @@
                          Value="{Binding SelectedItem.Order}" />
         </StackPanel>
 
+        <StackPanel Spacing="8">
+          <TextBlock Text="SelectedItem Shrink:" />
+          <NumericUpDown Minimum="0.0"
+                         IsEnabled="{Binding !!SelectedItem}"
+                         Value="{Binding SelectedItem.Shrink}" />
+        </StackPanel>
+
+        <StackPanel Spacing="8">
+          <TextBlock Text="SelectedItem Grow:" />
+          <NumericUpDown Minimum="0.0"
+                         IsEnabled="{Binding !!SelectedItem}"
+                         Value="{Binding SelectedItem.Grow}" />
+        </StackPanel>
+
         <Grid ColumnDefinitions="*,8,*">
 
           <Button Grid.Column="0"
@@ -147,7 +161,7 @@
     </ScrollViewer>
 
     <ItemsControl IsVisible="{Binding IsItemsControl}"
-                  BorderBrush="Black"
+                  BorderBrush="#666"
                   BorderThickness="1"
                   ItemsSource="{Binding Numbers}"
                   ItemTemplate="{StaticResource ItemTemplate}">
@@ -156,6 +170,8 @@
                x:DataType="vm:FlexItemViewModel">
           <Setter Property="panels:Flex.AlignSelf" Value="{Binding AlignSelf}" />
           <Setter Property="panels:Flex.Order" Value="{Binding Order}" />
+          <Setter Property="panels:Flex.Shrink" Value="{Binding Shrink}" />
+          <Setter Property="panels:Flex.Grow" Value="{Binding Grow}" />
           <Setter Property="IsVisible" Value="{Binding IsVisible}" />
         </Style>
       </ItemsControl.Styles>

--- a/samples/Avalonia.Labs.Catalog/Views/FlexView.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/FlexView.axaml
@@ -140,6 +140,30 @@
                          Value="{Binding SelectedItem.Grow}" />
         </StackPanel>
 
+        <StackPanel Spacing="8">
+          <TextBlock Text="SelectedItem Basis:" />
+          <ComboBox IsEnabled="{Binding !!SelectedItem}"
+                    ItemsSource="{Binding FlexBasisKindValues}"
+                    SelectedItem="{Binding SelectedItem.BasisKind}" />
+          <NumericUpDown Minimum="0.0"
+                         IsEnabled="{Binding !!SelectedItem}"
+                         Value="{Binding SelectedItem.BasisValue}" />
+        </StackPanel>
+
+        <StackPanel Spacing="8">
+          <TextBlock Text="SelectedItem HorizontalAlignment:" />
+          <ComboBox IsEnabled="{Binding !!SelectedItem}"
+                    ItemsSource="{Binding HorizontalAlignmentValues}"
+                    SelectedItem="{Binding SelectedItem.HorizontalAlignment}" />
+        </StackPanel>
+
+        <StackPanel Spacing="8">
+          <TextBlock Text="SelectedItem VerticalAlignment:" />
+          <ComboBox IsEnabled="{Binding !!SelectedItem}"
+                    ItemsSource="{Binding VerticalAlignmentValues}"
+                    SelectedItem="{Binding SelectedItem.VerticalAlignment}" />
+        </StackPanel>
+
         <Grid ColumnDefinitions="*,8,*">
 
           <Button Grid.Column="0"
@@ -172,6 +196,9 @@
           <Setter Property="panels:Flex.Order" Value="{Binding Order}" />
           <Setter Property="panels:Flex.Shrink" Value="{Binding Shrink}" />
           <Setter Property="panels:Flex.Grow" Value="{Binding Grow}" />
+          <Setter Property="panels:Flex.Basis" Value="{Binding Basis}" />
+          <Setter Property="HorizontalAlignment" Value="{Binding HorizontalAlignment}" />
+          <Setter Property="VerticalAlignment" Value="{Binding VerticalAlignment}" />
           <Setter Property="IsVisible" Value="{Binding IsVisible}" />
         </Style>
       </ItemsControl.Styles>

--- a/src/Avalonia.Labs.Panels/Flex.cs
+++ b/src/Avalonia.Labs.Panels/Flex.cs
@@ -18,11 +18,20 @@ namespace Avalonia.Labs.Panels
         public static readonly AttachedProperty<int> OrderProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, int>("Order", typeof(Flex));
 
+        public static readonly AttachedProperty<FlexBasis> BasisProperty =
+            AvaloniaProperty.RegisterAttached<Layoutable, FlexBasis>("Basis", typeof(Flex), FlexBasis.Auto);
+
         public static readonly AttachedProperty<double> ShrinkProperty =
-            AvaloniaProperty.RegisterAttached<Layoutable, double>("FlexShrink", typeof(Flex), 1.0, validate: v => v >= 0.0);
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("Shrink", typeof(Flex), 1.0, validate: v => v >= 0.0);
 
         public static readonly AttachedProperty<double> GrowProperty =
-            AvaloniaProperty.RegisterAttached<Layoutable, double>("FlexGrow", typeof(Flex), 0.0, validate: v => v >= 0.0);
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("Grow", typeof(Flex), 0.0, validate: v => v >= 0.0);
+
+        internal static readonly AttachedProperty<double> BaseLengthProperty =
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("BaseLength", typeof(Flex), 0.0);
+
+        internal static readonly AttachedProperty<double> CurrentLengthProperty =
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("CurrentLength", typeof(Flex), 0.0);
 
         /// <summary>
         /// Gets the child alignment in a flex layout
@@ -76,6 +85,26 @@ namespace Avalonia.Labs.Panels
             layoutable.SetValue(OrderProperty, value);
         }
 
+        public static FlexBasis GetBasis(Layoutable layoutable)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            return layoutable.GetValue(BasisProperty);
+        }
+
+        public static void SetBasis(Layoutable layoutable, FlexBasis value)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            layoutable.SetValue(BasisProperty, value);
+        }
+
         public static double GetShrink(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -114,6 +143,46 @@ namespace Avalonia.Labs.Panels
             }
 
             layoutable.SetValue(GrowProperty, value);
+        }
+
+        internal static double GetBaseLength(Layoutable layoutable)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            return layoutable.GetValue(BaseLengthProperty);
+        }
+
+        internal static void SetBaseLength(Layoutable layoutable, double value)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            layoutable.SetValue(BaseLengthProperty, value);
+        }
+
+        internal static double GetCurrentLength(Layoutable layoutable)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            return layoutable.GetValue(CurrentLengthProperty);
+        }
+
+        internal static void SetCurrentLength(Layoutable layoutable, double value)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            layoutable.SetValue(CurrentLengthProperty, value);
         }
     }
 }

--- a/src/Avalonia.Labs.Panels/Flex.cs
+++ b/src/Avalonia.Labs.Panels/Flex.cs
@@ -18,6 +18,12 @@ namespace Avalonia.Labs.Panels
         public static readonly AttachedProperty<int> OrderProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, int>("Order", typeof(Flex));
 
+        public static readonly AttachedProperty<double> ShrinkProperty =
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("FlexShrink", typeof(Flex), 1.0, validate: v => v >= 0.0);
+
+        public static readonly AttachedProperty<double> GrowProperty =
+            AvaloniaProperty.RegisterAttached<Layoutable, double>("FlexGrow", typeof(Flex), 0.0, validate: v => v >= 0.0);
+
         /// <summary>
         /// Gets the child alignment in a flex layout
         /// </summary>
@@ -68,6 +74,46 @@ namespace Avalonia.Labs.Panels
             }
 
             layoutable.SetValue(OrderProperty, value);
+        }
+
+        public static double GetShrink(Layoutable layoutable)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            return layoutable.GetValue(ShrinkProperty);
+        }
+
+        public static void SetShrink(Layoutable layoutable, double value)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            layoutable.SetValue(ShrinkProperty, value);
+        }
+
+        public static double GetGrow(Layoutable layoutable)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            return layoutable.GetValue(GrowProperty);
+        }
+
+        public static void SetGrow(Layoutable layoutable, double value)
+        {
+            if (layoutable is null)
+            {
+                throw new ArgumentNullException(nameof(layoutable));
+            }
+
+            layoutable.SetValue(GrowProperty, value);
         }
     }
 }

--- a/src/Avalonia.Labs.Panels/FlexBasis.cs
+++ b/src/Avalonia.Labs.Panels/FlexBasis.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Avalonia.Labs.Panels;
+
+public readonly struct FlexBasis : IEquatable<FlexBasis>
+{
+    public double Value { get; }
+
+    public FlexBasisKind Kind { get; }
+
+    public FlexBasis(double value, FlexBasisKind kind)
+    {
+        if (value < 0 || double.IsNaN(value) || double.IsInfinity(value))
+            throw new ArgumentException($"Invalid basis value: {value}", nameof(value));
+        if (kind < FlexBasisKind.Auto || kind > FlexBasisKind.Relative)
+            throw new ArgumentException($"Invalid basis kind: {kind}", nameof(kind));
+        Value = value;
+        Kind = kind;
+    }
+
+    public FlexBasis(double value) : this(value, FlexBasisKind.Absolute) { }
+
+    public static FlexBasis Auto => new(0.0, FlexBasisKind.Auto);
+
+    public bool IsAuto => Kind == FlexBasisKind.Auto;
+    
+    public bool IsAbsolute => Kind == FlexBasisKind.Absolute;
+    
+    public bool IsRelative => Kind == FlexBasisKind.Relative;
+
+    [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+    public bool Equals(FlexBasis other) =>
+        (IsAuto && other.IsAuto) || (Value == other.Value && Kind == other.Kind);
+
+    public override bool Equals(object? obj) =>
+        obj is FlexBasis other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Value, (int)Kind);
+
+    public static bool operator ==(FlexBasis left, FlexBasis right) =>
+        left.Equals(right);
+
+    public static bool operator !=(FlexBasis left, FlexBasis right) =>
+        !left.Equals(right);
+
+    public override string ToString()
+    {
+        return Kind switch
+        {
+            FlexBasisKind.Auto => "Auto",
+            FlexBasisKind.Absolute => FormattableString.Invariant($"{Value:G17}"),
+            FlexBasisKind.Relative => FormattableString.Invariant($"{Value * 100:G17}%"),
+            _ => throw new InvalidOperationException(),
+        };
+    }
+
+    public static FlexBasis Parse(string str)
+    {
+        return str.ToUpperInvariant() switch
+        {
+            "AUTO" => Auto,
+            var s when s.EndsWith("%") => new FlexBasis(ParseDouble(s[..^1].Trim()) / 100, FlexBasisKind.Relative),
+            _ => new FlexBasis(ParseDouble(str), FlexBasisKind.Absolute),
+        };
+        double ParseDouble(string s) => double.Parse(s, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Avalonia.Labs.Panels/FlexBasisKind.cs
+++ b/src/Avalonia.Labs.Panels/FlexBasisKind.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Labs.Panels;
+
+public enum FlexBasisKind
+{
+    Auto,
+    Absolute,
+    Relative,
+}

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -239,40 +239,29 @@ namespace Avalonia.Labs.Panels
             var isReverse = layout.Direction == FlexDirection.RowReverse || layout.Direction == FlexDirection.ColumnReverse;
 
             var state = _state ?? throw new InvalidOperationException();
-            var n = state.Sections.Count;
 
             var size = Uv.FromSize(finalSize, isColumn);
             var spacing = Uv.FromSize(layout.ColumnSpacing, layout.RowSpacing, isColumn);
 
+            var n = state.Sections.Count;
             var totalSectionV = state.Sections.Sum(s => s.V);
             var totalSpacingV = (n - 1) * spacing.V;
             var totalV = totalSectionV + totalSpacingV;
+            var freeV = size.V - totalV;
 
-            var spacingV = layout.AlignContent switch
+            var (spacingV, v) = layout.AlignContent switch
             {
-                AlignContent.FlexStart => spacing.V,
-                AlignContent.FlexEnd => spacing.V,
-                AlignContent.Center => spacing.V,
-                AlignContent.Stretch => spacing.V,
-                AlignContent.SpaceBetween => spacing.V + (size.V - totalV) / (n - 1),
-                AlignContent.SpaceAround => (size.V - totalSectionV) / n,
-                AlignContent.SpaceEvenly => (size.V - totalSectionV) / (n + 1),
+                AlignContent.FlexStart => (spacing.V, 0.0),
+                AlignContent.FlexEnd => (spacing.V, freeV),
+                AlignContent.Center => (spacing.V, freeV / 2),
+                AlignContent.Stretch => (spacing.V, 0.0),
+                AlignContent.SpaceBetween => (spacing.V + freeV / (n - 1), 0.0),
+                AlignContent.SpaceAround => (spacing.V + freeV / n, freeV / n / 2),
+                AlignContent.SpaceEvenly => (spacing.V + freeV / (n + 1), freeV / (n + 1)),
                 _ => throw new NotImplementedException()
             };
 
             var scaleV = layout.AlignContent == AlignContent.Stretch ? ((size.V - totalSpacingV) / totalSectionV) : 1.0;
-
-            var v = layout.AlignContent switch
-            {
-                AlignContent.FlexStart => 0.0,
-                AlignContent.FlexEnd => size.V - totalV,
-                AlignContent.Center => (size.V - totalV) / 2,
-                AlignContent.Stretch => 0,
-                AlignContent.SpaceBetween => 0.0,
-                AlignContent.SpaceAround => spacingV / 2,
-                AlignContent.SpaceEvenly => spacingV,
-                _ => throw new NotImplementedException()
-            };
 
             foreach (var section in state.Sections)
             {

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -249,7 +249,15 @@ namespace Avalonia.Labs.Panels
             var totalV = totalSectionV + totalSpacingV;
             var freeV = size.V - totalV;
 
-            var (spacingV, v) = layout.AlignContent switch
+            var alignContent = freeV >= 0.0 ? layout.AlignContent : layout.AlignContent switch
+            {
+                AlignContent.FlexStart or AlignContent.Stretch or AlignContent.SpaceBetween => AlignContent.FlexStart,
+                AlignContent.Center or AlignContent.SpaceAround or AlignContent.SpaceEvenly => AlignContent.Center,
+                AlignContent.FlexEnd => AlignContent.FlexEnd,
+                _ => throw new NotImplementedException()
+            };
+
+            var (spacingV, v) = alignContent switch
             {
                 AlignContent.FlexStart => (spacing.V, 0.0),
                 AlignContent.FlexEnd => (spacing.V, freeV),
@@ -261,7 +269,7 @@ namespace Avalonia.Labs.Panels
                 _ => throw new NotImplementedException()
             };
 
-            var scaleV = layout.AlignContent == AlignContent.Stretch ? ((size.V - totalSpacingV) / totalSectionV) : 1.0;
+            var scaleV = alignContent == AlignContent.Stretch ? (size.V - totalSpacingV) / totalSectionV : 1.0;
 
             foreach (var section in state.Sections)
             {

--- a/src/Avalonia.Labs.Panels/Uv.cs
+++ b/src/Avalonia.Labs.Panels/Uv.cs
@@ -23,5 +23,8 @@
 
         public static Size ToSize(Uv uv, bool swap) =>
             new Size(swap ? uv.V : uv.U, swap ? uv.U : uv.V);
+
+        public override string ToString() =>
+            $"U: {U}, V: {V}";
     }
 }

--- a/src/Avalonia.Labs.Panels/Uv.cs
+++ b/src/Avalonia.Labs.Panels/Uv.cs
@@ -24,6 +24,12 @@
         public static Size ToSize(Uv uv, bool swap) =>
             new Size(swap ? uv.V : uv.U, swap ? uv.U : uv.V);
 
+        public Uv WithU(double u) =>
+            new Uv(u, V);
+
+        public Uv WithV(double v) =>
+            new Uv(U, v);
+
         public override string ToString() =>
             $"U: {U}, V: {V}";
     }


### PR DESCRIPTION
Several enhancements to `FlexPanel`:

1. Fixed implementation of `justify-content` and `align-content` to follow the correct spacing calculation like in HTML. The original implementation was off in case of non-zero row and column gaps. Frankly, all variations looks kinda messy, but one is at least the standardized mess.

2. Fixed implementation of `align-content` in case of items overflowing out of available panel size. In HTML, it falls back to three basic cases.

3. Implemented `flex-shrink` and `flex-grow`. It's a very basic implementation which performs all calculations in the arrange stage. It covers the basic case of stretching items in wrap and no-wrap modes, as well as shrinking in no-wrap mode.

Proper flexbox implementation with fully functional `flex-grow` and `flex-shrink` would require support for `flex-basis`, much more sophisticated measure stage to handle min/max width/height constraints, resizing across main axis affecting cross axis and stuff like this. I don't understand HTML's and Avalonia's layout systems enough to properly match everything, so only basic implementation is included.

Maybe I'll implement `flex-basis` later. Using it as percent/absolute main axis constraint at the measure stage sounds potentially useful (?).

If anybody is curious, here's the [official specification of the flex layout algorithm](https://www.w3.org/TR/css-flexbox-1/#layout-algorithm).

P.S. Is there any reason to use `RowSpacing` and `ColumnSpacing` property names instead of `RowGap` and `ColumnGap`? This seems to be the only mismatch with HTML flexbox naming. [EDIT] I see, there's `Spacing` in `StackPanel`.