### PR TITLE
Fixes QuietZone in QR code

### DIFF
--- a/src/Avalonia.Labs.Qr/QrCode.cs
+++ b/src/Avalonia.Labs.Qr/QrCode.cs
@@ -41,6 +41,14 @@ namespace Avalonia.Labs.Qr
         /// </summary>
         public static readonly StyledProperty<Thickness> PaddingProperty = Decorator.PaddingProperty.AddOwner<QrCode>();
         /// <summary>
+        /// Property indicating whether the Quiet Zone of 4 modules should be added to the QR Code as additional padding.  Default: True
+        ///
+        /// Note: Disabling the Quiet Zone makes the generated QRCodes "non-standard" according to the ISO 18004 standard.
+        /// The padding created by the Quiet Zone depends on the module size and therefore on the amount of data. This can be
+        /// disabled and a fixed <see cref="Padding"/> can be set instead to have more control over the layout. 
+        /// </summary>
+        public static readonly StyledProperty<bool> IsQuietZoneEnabledProperty = AvaloniaProperty.Register<QrCode, bool>(nameof(IsQuietZoneEnabled), true);
+        /// <summary>
         /// Property indicating the Error Correction Code of the generated data.  Default: Medium
         ///
         /// Note: See <see cref="EccLevel" /> for the specific definitions of each value.
@@ -75,6 +83,12 @@ namespace Avalonia.Labs.Qr
             get => GetValue(PaddingProperty);
             set => SetValue(PaddingProperty, value);
         }
+        /// <inheritdoc cref="IsQuietZoneEnabledProperty" />
+        public bool IsQuietZoneEnabled
+        {
+            get => GetValue(IsQuietZoneEnabledProperty);
+            set => SetValue(IsQuietZoneEnabledProperty, value);
+        }
         /// <inheritdoc cref="ErrorCorrectionProperty" />
         public EccLevel ErrorCorrection
         {
@@ -103,8 +117,8 @@ namespace Avalonia.Labs.Qr
         private Gma.QrCodeNet.Encoding.QrCode? _encodedQrCode;
         
         // QRCode specs mandate a standard 4-symbol-sized space on each side of the data.  We support custom Padding and will ignore this zone when processing
-        private const int QuietZoneCount = 4;
-        private const int QuietMargin = QuietZoneCount * 2;
+        private int QuietZoneCount => IsQuietZoneEnabled ? 4 : 0;
+        private int QuietMargin => QuietZoneCount * 2;
 
         /// <summary>
         /// Defines the geometry of the previously displayed QRCode
@@ -177,6 +191,7 @@ namespace Avalonia.Labs.Qr
                 case nameof(Padding):
                 case nameof(Width):
                 case nameof(Height):
+                case nameof(IsQuietZoneEnabled):
                 case nameof(ErrorCorrection):
                 case nameof(Data):
                     OnLayoutChanged(_encodedQrCode);


### PR DESCRIPTION
Fixes #51 

The original implementation removed 4 bits on every side instead of adding 4 white pixels as a quite zone. This resulted in data loose and broke the QR codes.

1. This PR reversed the logic, repaired the qr data and added an actual quite zone.

2. ~~_Off-topic:_ Should I also add a _bool_ to disable the quite zone? The thickness of the quite zone is depending of bit matrix's size. You get less padding with more data. Maybe the user want to use a fixed `Padding` instead.~~
Added `IsQuietZoneEnabledProperty` to disable the Quiet Zone.

3. This also fixed an issue where `Width` and `Height` changes won't re-render the QRCode. Also also added a cache, so the QRCode data is not re-generated for just layout changes.

![grafik](https://github.com/AvaloniaUI/Avalonia.Labs/assets/6116717/edf13a20-3158-45d8-ab72-1fa96dfbdcb7)
