### PR TITLE
Fix AsyncImage CornerRadius not working

### DIFF
--- a/src/Avalonia.Labs.Controls/Themes/Controls/AsyncImage.xaml
+++ b/src/Avalonia.Labs.Controls/Themes/Controls/AsyncImage.xaml
@@ -17,6 +17,7 @@
         <ControlTemplate>
             <Border Margin="0"
                     Padding="0"
+                    ClipToBounds="True"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"


### PR DESCRIPTION
Adds ClipToBounds=True to AsyncImage's Border to have CornerRadius working properly