### PR TITLE
flexpanel: avoid division by 0

### DIFF
--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Labs.Panels
             var totalV = totalLineV + totalSpacingV;
             var freeV = panelSize.V - totalV;
 
-            var alignContent = freeV >= 0.0 ? AlignContent : AlignContent switch
+            var alignContent = freeV > 0.0 ? AlignContent : AlignContent switch
             {
                 AlignContent.FlexStart or AlignContent.Stretch or AlignContent.SpaceBetween => AlignContent.FlexStart,
                 AlignContent.Center or AlignContent.SpaceAround or AlignContent.SpaceEvenly => AlignContent.Center,


### PR DESCRIPTION
fixes #58 

From my (limited) understanding this shouldn't affect any other cases since there is no vertical space left anyways. So the content alignment is essentially irrelevant.