### PR TITLE
Fix pan gesture losing pointer capture

### DIFF
--- a/src/Avalonia.Labs.Controls/Base/Pan/PanGestureRecongnizer.cs
+++ b/src/Avalonia.Labs.Controls/Base/Pan/PanGestureRecongnizer.cs
@@ -80,6 +80,7 @@ public class PanGestureRecognizer : GestureRecognizer
             e.Pointer.Capture(_inputElement);
             OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Started, 0, 0));
             e.Handled = true;
+            Capture(e.Pointer);
         }
 
         OnPan?.Invoke(_inputElement, new PanUpdatedEventArgs(PanGestureStatus.Running, _delta.X, _delta.Y));


### PR DESCRIPTION
Gestures that track the pointer over multiple moves now need to capture the pointer.

Fixes #63 .

There is an issue with pointers not resetting their capture when released. This is fix in Avalonia master, but not in beta.