### PR TITLE
Fix/pan gesture pointer tracking

### DIFF
--- a/src/Avalonia.Labs.Controls/Base/Pan/PanGestureRecognizer.cs
+++ b/src/Avalonia.Labs.Controls/Base/Pan/PanGestureRecognizer.cs
@@ -32,7 +32,6 @@ public class PanGestureRecognizer : GestureRecognizer
         _tracking = e.Pointer;
         _visual = Target as Visual;
         _parent = _visual?.Parent as Visual;
-        _state = PanGestureStatus.Completed;
         _startPosition = e.GetPosition(_parent);
         _state = PanGestureStatus.Started;
     }
@@ -93,7 +92,7 @@ public class PanGestureRecognizer : GestureRecognizer
     /// <inheritdoc />
     protected override void PointerReleased(PointerReleasedEventArgs e)
     {
-        if (_tracking is null || e.Pointer != _tracking)
+        if (e.Pointer != _tracking)
         {
             return;
         }
@@ -117,7 +116,6 @@ public class PanGestureRecognizer : GestureRecognizer
     /// <inheritdoc />
     protected override void PointerCaptureLost(IPointer pointer)
     {
-        var startPosition = _startPosition;
         var delta = _delta;
 
         _tracking = null;


### PR DESCRIPTION
Addresses #69 by making sure that the correct pointer is being tracked while panning.

I've also tweaked the private fields so only the necessary ones are recorded and `_startPosition` isn't nullable - it doesn't need to be any more because it knowing whether a pointer is being tracked is enough to know whether we should be handling PointerMoved events.