### PR TITLE
Update FlexPanel default property values to match FlexBox specification 

### DIFF
--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -28,19 +28,19 @@ namespace Avalonia.Labs.Panels
         /// Defines the <see cref="AlignItems"/> property.
         /// </summary>
         public static readonly StyledProperty<AlignItems> AlignItemsProperty =
-            AvaloniaProperty.Register<FlexPanel, AlignItems>(nameof(AlignItems));
+            AvaloniaProperty.Register<FlexPanel, AlignItems>(nameof(AlignItems), AlignItems.Stretch);
 
         /// <summary>
         /// Defines the <see cref="AlignContent"/> property.
         /// </summary>
         public static readonly StyledProperty<AlignContent> AlignContentProperty =
-            AvaloniaProperty.Register<FlexPanel, AlignContent>(nameof(AlignContent));
+            AvaloniaProperty.Register<FlexPanel, AlignContent>(nameof(AlignContent), AlignContent.Stretch);
 
         /// <summary>
         /// Defines the <see cref="Wrap"/> property.
         /// </summary>
         public static readonly StyledProperty<FlexWrap> WrapProperty =
-            AvaloniaProperty.Register<FlexPanel, FlexWrap>(nameof(Wrap), FlexWrap.Wrap);
+            AvaloniaProperty.Register<FlexPanel, FlexWrap>(nameof(Wrap));
 
         /// <summary>
         /// Defines the <see cref="ColumnSpacing"/> property.


### PR DESCRIPTION
### Problem:
Some of the properties of `FlexPanel` have initial values that don't match the official specification of `FlexBox`. 
[Specification](https://www.w3.org/TR/css-flexbox-1/#property-index)

This caused default behavior of the `FlexPanel` to be inconsistent with `FlexBox` behavior, which it is supposed to be emulating.

### Changes:
- `AlignItems` property: 
    - old:   `AlignItems.FlexStart` 
    - new: `AlignItems.Stretch`
- `AlignContents` property: 
    - old: `AlignContent.FlexStart` 
    - new: `AlignContent.Stretch`
- `Wrap` property: 
    - old: `FlexWrap.Wrap` 
    - new: `FlexWrap.NoWrap`

All new values were taken from the official `FlexBox` [Specification](https://www.w3.org/TR/css-flexbox-1/#property-index).

### Impact:
This is a breaking change with respect to the default behavior of the `FlexPanel` and is likely to cause a disruption to current users updating to the new version.

To fix any unwanted changes in behavior, each usage of `FlexPanel` would have to be checked and updates be made to overrule the new default property values with the old ones.

Since this would be quite a tedious process, the following styles are provided as an alternative to revert the initial values to what they were before this PR.

```xml
<!-- Override FlexPanel initial values to revert https://github.com/AvaloniaUI/Avalonia.Labs/pull/74 -->
<Style Selector="panels|FlexPanel">
  <Setter Property="AlignItems" Value="FlexStart" />
  <Setter Property="AlignContent" Value="FlexStart" />
  <Setter Property="Wrap" Value="Wrap" />
</Style>
```

While this change will cause disruption in the short term, it should prove a benefit in the long run.
This is specifically useful to developers adapting UI designs into Avalonia from HTML/CSS based sources, like Figma or other deign tools or existing UIs.

Having different defaults from `FlexBox` results in confusion and frustrations for the developers.

Since the whole point of this `Avalonia.Labs` repository is to host controls and panels that are not API stable, it feels important to make this kind of changes now. 