### PR TITLE
Add FlexPanel Docs

### DIFF
--- a/src/Avalonia.Labs.Panels/AlignContent.cs
+++ b/src/Avalonia.Labs.Panels/AlignContent.cs
@@ -1,13 +1,46 @@
 ﻿namespace Avalonia.Labs.Panels
 {
+    /// <summary>
+    /// Defines the alignment mode of the lines inside a <see cref="FlexPanel"/> along the cross-axis. 
+    /// </summary>
     public enum AlignContent
     {
+        /// <summary>
+        /// Lines are packed toward the start of the container.
+        /// </summary>
         FlexStart,
+        
+        /// <summary>
+        /// Lines are packed toward the end of the container.
+        /// </summary>
         FlexEnd,
+        
+        /// <summary>
+        /// Lines are packed toward the center of the container
+        /// </summary>
         Center,
+        
+        /// <summary>
+        /// Lines are stretched to take up the remaining space.
+        /// </summary>
+        /// <remarks>
+        /// This is the default value.
+        /// </remarks>
         Stretch,
+        
+        /// <summary>
+        /// Lines are evenly distributed in the container, with no space on either end.
+        /// </summary>
         SpaceBetween,
+        
+        /// <summary>
+        /// Lines are evenly distributed in the container, with half-size spaces on either end.
+        /// </summary>
         SpaceAround,
+        
+        /// <summary>
+        /// Lines are evenly distributed in the container, with equal-size spaces between each line and on either end. 
+        /// </summary>
         SpaceEvenly
     }
 }

--- a/src/Avalonia.Labs.Panels/AlignItems.cs
+++ b/src/Avalonia.Labs.Panels/AlignItems.cs
@@ -22,7 +22,8 @@ namespace Avalonia.Labs.Panels
         /// Items are aligned to the cross-axis center of the line.
         /// </summary>
         /// <remarks>
-        /// If the cross size of the line is less than that of the child item, it will overflow equally in both directions.
+        /// If the cross size of the line is less than that of the child item,
+        /// it will overflow equally in both directions.
         /// </remarks>
         Center,
         

--- a/src/Avalonia.Labs.Panels/AlignItems.cs
+++ b/src/Avalonia.Labs.Panels/AlignItems.cs
@@ -2,12 +2,36 @@
 
 namespace Avalonia.Labs.Panels
 {
+    /// <summary>
+    /// Defines the alignment mode along the cross-axis of <see cref="FlexPanel"/> child items.
+    /// </summary>
     [SuppressMessage("Naming", "CA1717:Only FlagsAttribute enums should have plural names")]
     public enum AlignItems
     {
+        /// <summary>
+        /// Items are aligned to the cross-axis start margin edge of the line.
+        /// </summary>
         FlexStart,
+        
+        /// <summary>
+        /// Items are aligned to the cross-axis end margin edge of the line.
+        /// </summary>
         FlexEnd,
+        
+        /// <summary>
+        /// Items are aligned to the cross-axis center of the line.
+        /// </summary>
+        /// <remarks>
+        /// If the cross size of the line is less than that of the child item, it will overflow equally in both directions.
+        /// </remarks>
         Center,
+        
+        /// <summary>
+        /// Items are stretched to fill the cross size of the line.
+        /// </summary>
+        /// <remarks>
+        /// This is the default value.
+        /// </remarks>
         Stretch
     }
 }

--- a/src/Avalonia.Labs.Panels/Flex.cs
+++ b/src/Avalonia.Labs.Panels/Flex.cs
@@ -48,6 +48,7 @@ namespace Avalonia.Labs.Panels
         /// <remarks>
         /// This property is used to override the <see cref="FlexPanel.AlignItems"/> property for a specific child.
         /// When omitted, <see cref="FlexPanel.AlignItems"/> in not overridden.
+        /// Equivalent to CSS align-self property.
         /// </remarks>
         public static AlignItems? GetAlignSelf(Layoutable layoutable)
         {
@@ -65,6 +66,7 @@ namespace Avalonia.Labs.Panels
         /// <remarks>
         /// This property is used to override the <see cref="FlexPanel.AlignItems"/> property for a specific child.
         /// When omitted, <see cref="FlexPanel.AlignItems"/> in not overridden.
+        /// Equivalent to CSS align-self property.
         /// </remarks>
         public static void SetAlignSelf(Layoutable layoutable, AlignItems? value)
         {
@@ -83,6 +85,7 @@ namespace Avalonia.Labs.Panels
         /// A lower order value means the item will be positioned earlier within the container.
         /// Items with the same order value are laid out in their source document order.
         /// When omitted, it is set to 0.
+        /// Equivalent to CSS order property.
         /// </remarks>
         public static int GetOrder(Layoutable layoutable)
         {
@@ -101,6 +104,7 @@ namespace Avalonia.Labs.Panels
         /// A lower order value means the item will be positioned earlier within the container.
         /// Items with the same order value are laid out in their source document order.
         /// When omitted, it is set to 0.
+        /// Equivalent to CSS order property.
         /// </remarks>
         public static void SetOrder(Layoutable layoutable, int value)
         {
@@ -119,6 +123,7 @@ namespace Avalonia.Labs.Panels
         /// <remarks>
         /// Either automatic size, a fixed length, or a percentage of the container's size.
         /// When omitted, it is set to <see cref="FlexBasis.Auto"/>.
+        /// Equivalent to CSS flex-basis property.
         /// </remarks>
         public static FlexBasis GetBasis(Layoutable layoutable)
         {
@@ -137,6 +142,7 @@ namespace Avalonia.Labs.Panels
         /// <remarks>
         /// Either automatic size, a fixed length, or a percentage of the container's size.
         /// When omitted, it is set to <see cref="FlexBasis.Auto"/>.
+        /// Equivalent to CSS flex-basis property.
         /// </remarks>
         public static void SetBasis(Layoutable layoutable, FlexBasis value)
         {
@@ -153,6 +159,7 @@ namespace Avalonia.Labs.Panels
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 1.
+        /// Equivalent to CSS flex-shrink property.
         /// </remarks>
         public static double GetShrink(Layoutable layoutable)
         {
@@ -169,6 +176,7 @@ namespace Avalonia.Labs.Panels
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 1.
+        /// Equivalent to CSS flex-shrink property.
         /// </remarks>
         public static void SetShrink(Layoutable layoutable, double value)
         {
@@ -185,6 +193,7 @@ namespace Avalonia.Labs.Panels
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 0.
+        /// Equivalent to CSS flex-grow property.
         /// </remarks>
         public static double GetGrow(Layoutable layoutable)
         {
@@ -201,6 +210,7 @@ namespace Avalonia.Labs.Panels
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 0.
+        /// Equivalent to CSS flex-grow property.
         /// </remarks>
         public static void SetGrow(Layoutable layoutable, double value)
         {

--- a/src/Avalonia.Labs.Panels/Flex.cs
+++ b/src/Avalonia.Labs.Panels/Flex.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Labs.Panels
     public static class Flex
     {
         /// <summary>
-        /// Defines an attached property to control the alignment of a specific child in a flex layout.
+        /// Defines an attached property to control the cross-axis alignment of a specific child in a flex layout.
         /// </summary>
         public static readonly AttachedProperty<AlignItems?> AlignSelfProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, AlignItems?>("AlignSelf", typeof(Flex));
@@ -18,12 +18,21 @@ namespace Avalonia.Labs.Panels
         public static readonly AttachedProperty<int> OrderProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, int>("Order", typeof(Flex));
 
+        /// <summary>
+        /// Defines an attached property to control the initial main-axis size of a specific child in a flex layout.
+        /// </summary>
         public static readonly AttachedProperty<FlexBasis> BasisProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, FlexBasis>("Basis", typeof(Flex), FlexBasis.Auto);
 
+        /// <summary>
+        /// Defines an attached property to control the factor by which a specific child can shrink along the main-axis in a flex layout.
+        /// </summary>
         public static readonly AttachedProperty<double> ShrinkProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, double>("Shrink", typeof(Flex), 1.0, validate: v => v >= 0.0);
 
+        /// <summary>
+        /// Defines an attached property to control the factor by which a specific child can grow along the main-axis in a flex layout.
+        /// </summary>
         public static readonly AttachedProperty<double> GrowProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, double>("Grow", typeof(Flex), 0.0, validate: v => v >= 0.0);
 
@@ -34,8 +43,12 @@ namespace Avalonia.Labs.Panels
             AvaloniaProperty.RegisterAttached<Layoutable, double>("CurrentLength", typeof(Flex), 0.0);
 
         /// <summary>
-        /// Gets the child alignment in a flex layout
+        /// Gets the cross-axis alignment override for a child item in a <see cref="FlexPanel"/>
         /// </summary>
+        /// <remarks>
+        /// This property is used to override the <see cref="FlexPanel.AlignItems"/> property for a specific child.
+        /// When omitted, <see cref="FlexPanel.AlignItems"/> in not overridden.
+        /// </remarks>
         public static AlignItems? GetAlignSelf(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -47,8 +60,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Sets the child alignment in a flex layout
+        /// Sets the cross-axis alignment override for a child item in a <see cref="FlexPanel"/>
         /// </summary>
+        /// <remarks>
+        /// This property is used to override the <see cref="FlexPanel.AlignItems"/> property for a specific child.
+        /// When omitted, <see cref="FlexPanel.AlignItems"/> in not overridden.
+        /// </remarks>
         public static void SetAlignSelf(Layoutable layoutable, AlignItems? value)
         {
             if (layoutable is null)
@@ -60,8 +77,13 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets the child order in a flex layout
+        /// Retrieves the order in which a child item appears within the <see cref="FlexPanel"/>.
         /// </summary>
+        /// <remarks>
+        /// A lower order value means the item will be positioned earlier within the container.
+        /// Items with the same order value are laid out in their source document order.
+        /// When omitted, it is set to 0.
+        /// </remarks>
         public static int GetOrder(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -73,8 +95,13 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Sets the child order in a flex layout
+        /// Sets the order in which a child item appears within the <see cref="FlexPanel"/>.
         /// </summary>
+        /// <remarks>
+        /// A lower order value means the item will be positioned earlier within the container.
+        /// Items with the same order value are laid out in their source document order.
+        /// When omitted, it is set to 0.
+        /// </remarks>
         public static void SetOrder(Layoutable layoutable, int value)
         {
             if (layoutable is null)
@@ -85,6 +112,14 @@ namespace Avalonia.Labs.Panels
             layoutable.SetValue(OrderProperty, value);
         }
 
+        /// <summary>
+        /// Gets the initial size along the main-axis of an item in a <see cref="FlexPanel"/>,
+        /// before free space is distributed according to the flex factors.
+        /// </summary>
+        /// <remarks>
+        /// Either automatic size, a fixed length, or a percentage of the container's size.
+        /// When omitted, it is set to <see cref="FlexBasis.Auto"/>.
+        /// </remarks>
         public static FlexBasis GetBasis(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -95,6 +130,14 @@ namespace Avalonia.Labs.Panels
             return layoutable.GetValue(BasisProperty);
         }
 
+        /// <summary>
+        /// Sets the initial size along the main-axis of an item in a <see cref="FlexPanel"/>,
+        /// before free space is distributed according to the flex factors.
+        /// </summary>
+        /// <remarks>
+        /// Either automatic size, a fixed length, or a percentage of the container's size.
+        /// When omitted, it is set to <see cref="FlexBasis.Auto"/>.
+        /// </remarks>
         public static void SetBasis(Layoutable layoutable, FlexBasis value)
         {
             if (layoutable is null)
@@ -105,6 +148,12 @@ namespace Avalonia.Labs.Panels
             layoutable.SetValue(BasisProperty, value);
         }
 
+        /// <summary>
+        /// Gets the factor by which an item can shrink along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// </summary>
+        /// <remarks>
+        /// When omitted, it is set to 1.
+        /// </remarks>
         public static double GetShrink(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -115,6 +164,12 @@ namespace Avalonia.Labs.Panels
             return layoutable.GetValue(ShrinkProperty);
         }
 
+        /// <summary>
+        /// Sets the factor by which an item can shrink along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// </summary>
+        /// <remarks>
+        /// When omitted, it is set to 1.
+        /// </remarks>
         public static void SetShrink(Layoutable layoutable, double value)
         {
             if (layoutable is null)
@@ -125,6 +180,12 @@ namespace Avalonia.Labs.Panels
             layoutable.SetValue(ShrinkProperty, value);
         }
 
+        /// <summary>
+        /// Gets the factor by which an item can grow along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// </summary>
+        /// <remarks>
+        /// When omitted, it is set to 0.
+        /// </remarks>
         public static double GetGrow(Layoutable layoutable)
         {
             if (layoutable is null)
@@ -135,6 +196,12 @@ namespace Avalonia.Labs.Panels
             return layoutable.GetValue(GrowProperty);
         }
 
+        /// <summary>
+        /// Sets the factor by which an item can grow along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// </summary>
+        /// <remarks>
+        /// When omitted, it is set to 0.
+        /// </remarks>
         public static void SetGrow(Layoutable layoutable, double value)
         {
             if (layoutable is null)

--- a/src/Avalonia.Labs.Panels/Flex.cs
+++ b/src/Avalonia.Labs.Panels/Flex.cs
@@ -25,13 +25,15 @@ namespace Avalonia.Labs.Panels
             AvaloniaProperty.RegisterAttached<Layoutable, FlexBasis>("Basis", typeof(Flex), FlexBasis.Auto);
 
         /// <summary>
-        /// Defines an attached property to control the factor by which a specific child can shrink along the main-axis in a flex layout.
+        /// Defines an attached property to control the factor by which a specific child can shrink
+        /// along the main-axis in a flex layout.
         /// </summary>
         public static readonly AttachedProperty<double> ShrinkProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, double>("Shrink", typeof(Flex), 1.0, validate: v => v >= 0.0);
 
         /// <summary>
-        /// Defines an attached property to control the factor by which a specific child can grow along the main-axis in a flex layout.
+        /// Defines an attached property to control the factor by which a specific child can grow
+        /// along the main-axis in a flex layout.
         /// </summary>
         public static readonly AttachedProperty<double> GrowProperty =
             AvaloniaProperty.RegisterAttached<Layoutable, double>("Grow", typeof(Flex), 0.0, validate: v => v >= 0.0);
@@ -155,7 +157,8 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets the factor by which an item can shrink along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// Gets the factor by which an item can shrink along the main-axis,
+        /// relative to other items in a <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 1.
@@ -172,7 +175,8 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Sets the factor by which an item can shrink along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// Sets the factor by which an item can shrink along the main-axis,
+        /// relative to other items in a <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 1.
@@ -189,7 +193,8 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets the factor by which an item can grow along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// Gets the factor by which an item can grow along the main-axis,
+        /// relative to other items in a <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 0.
@@ -206,7 +211,8 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Sets the factor by which an item can grow along the main-axis, relative to other items in a <see cref="FlexPanel"/>.
+        /// Sets the factor by which an item can grow along the main-axis,
+        /// relative to other items in a <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to 0.

--- a/src/Avalonia.Labs.Panels/FlexDirection.cs
+++ b/src/Avalonia.Labs.Panels/FlexDirection.cs
@@ -8,6 +8,9 @@
         /// <summary>
         /// Items are placed along the horizontal axis, starting from the left
         /// </summary>
+        /// <remarks>
+        /// This is the default value.
+        /// </remarks>
         Row,
         
         /// <summary>

--- a/src/Avalonia.Labs.Panels/FlexDirection.cs
+++ b/src/Avalonia.Labs.Panels/FlexDirection.cs
@@ -1,10 +1,28 @@
 ﻿namespace Avalonia.Labs.Panels
 {
+    /// <summary>
+    /// Describes the orientation and direction along which items are placed inside the <see cref="FlexPanel"/>
+    /// </summary>
     public enum FlexDirection
     {
+        /// <summary>
+        /// Items are placed along the horizontal axis, starting from the left
+        /// </summary>
         Row,
+        
+        /// <summary>
+        /// Items are placed along the horizontal axis, starting from the right
+        /// </summary>
         RowReverse,
+        
+        /// <summary>
+        /// Items are placed along the vertical axis, starting from the top
+        /// </summary>
         Column,
+        
+        /// <summary>
+        /// Items are placed along the vertical axis, starting from the bottom
+        /// </summary>
         ColumnReverse
     }
 }

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -9,8 +9,8 @@ namespace Avalonia.Labs.Panels
 {
 
     /// <summary>
-    /// A panel that arranges its child controls using CSS FlexBox principles.
-    /// It organizes children one or more lines along a main-axis (either row or column)
+    /// A panel that arranges child controls using CSS FlexBox principles.
+    /// It organizes child items in one or more lines along a main-axis (either row or column)
     /// and provides advanced control over their sizing and layout.
     /// </summary>
     /// <remarks>
@@ -105,7 +105,7 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the alignment of child controls along the main-axis of the current line of the <see cref="FlexPanel"/>.
+        /// Gets or sets the main-axis alignment of child items inside a line of the <see cref="FlexPanel"/>.
         /// Typically used to distribute extra free space leftover after flexible lengths and margins have been resolved.
         /// </summary>
         /// <remarks>
@@ -119,7 +119,7 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the default alignment for all the child controls along the cross-axis of the current line.
+        /// Gets or sets the cross-axis alignment of all child items inside a line of the <see cref="FlexPanel"/>.
         /// Similar to <see cref="JustifyContent"/>, but in the perpendicular direction.
         /// </summary>
         /// <remarks>
@@ -133,9 +133,10 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the alignment of lines in the <see cref="FlexPanel"/> when there is extra space in the cross-axis. 
+        /// Gets or sets the cross-axis alignment of lines in the <see cref="FlexPanel"/> when there is extra space. 
         /// Similar to <see cref="AlignItems"/>, but for entire lines.
-        /// Useful when <see cref="Wrap"/> mode allows controls to be arranged on multiple lines. 
+        /// <see cref="FlexPanel.Wrap"/> property set to <see cref="FlexWrap.Wrap"/> mode
+        /// allows controls to be arranged on multiple lines.
         /// </summary>
         /// <remarks>
         /// When omitted, it is set to <see cref="AlignContent.Stretch"/>.
@@ -162,7 +163,7 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the minimum horizontal spacing between child controls or lines,
+        /// Gets or sets the minimum horizontal spacing between child items or lines,
         /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
@@ -176,7 +177,7 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the minimum vertical spacing between child controls or lines,
+        /// Gets or sets the minimum vertical spacing between child items or lines,
         /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -7,6 +7,15 @@ using Avalonia.Layout;
 
 namespace Avalonia.Labs.Panels
 {
+
+    /// <summary>
+    /// A panel that arranges its child controls using CSS FlexBox principles.
+    /// It organizes children one or more lines along a main-axis (either row or column)
+    /// and provides advanced control over their sizing and layout.
+    /// </summary>
+    /// <remarks>
+    /// See CSS FlexBox specification: https://www.w3.org/TR/css-flexbox-1
+    /// </remarks>
     public sealed class FlexPanel : Panel
     {
         private static readonly Func<Layoutable, int> s_getOrder = x => x is { } y ? Flex.GetOrder(y) : 0;
@@ -82,8 +91,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the flex direction
+        /// Gets or sets the direction of the <see cref="FlexPanel"/>'s main-axis,
+        /// determining the orientation in which child controls are laid out.
         /// </summary>
+        /// <remarks>
+        /// Equivalent to CSS flex-direction property
+        /// </remarks>
         public FlexDirection Direction
         {
             get => GetValue(DirectionProperty);
@@ -91,8 +104,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the flex justify content mode
+        /// Gets or sets the alignment of child controls along the main-axis of the current line of the <see cref="FlexPanel"/>.
+        /// Typically used to distribute extra free space leftover after flexible lengths and margins have been resolved.
         /// </summary>
+        /// <remarks>
+        /// Equivalent to CSS justify-content property.
+        /// </remarks>
         public JustifyContent JustifyContent
         {
             get => GetValue(JustifyContentProperty);
@@ -100,8 +117,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the flex align items mode
+        /// Gets or sets the default alignment for all the child controls along the cross-axis of the current line.
+        /// Similar to <see cref="JustifyContent"/>, but in the perpendicular direction.
         /// </summary>
+        /// <remarks>
+        /// Equivalent to CSS align-items property.
+        /// </remarks>
         public AlignItems AlignItems
         {
             get => GetValue(AlignItemsProperty);
@@ -109,8 +130,13 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the flex align content mode
+        /// Gets or sets the alignment of lines in the <see cref="FlexPanel"/> when there is extra space in the cross-axis. 
+        /// Similar to <see cref="AlignItems"/>, but for entire lines.
+        /// Useful when <see cref="Wrap"/> mode allows controls to be arranged on multiple lines. 
         /// </summary>
+        /// <remarks>
+        /// Equivalent to CSS align-content property.
+        /// </remarks>
         public AlignContent AlignContent
         {
             get => GetValue(AlignContentProperty);
@@ -118,8 +144,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the flex wrap mode
+        /// Gets or sets the wrap mode, controlling whether the <see cref="FlexPanel"/> is single-line or multi-line.
+        /// Additionally, it determines the cross-axis stacking direction for new lines.
         /// </summary>
+        /// <remarks>
+        /// Equivalent to CSS flex-wrap property.
+        /// </remarks>
         public FlexWrap Wrap
         {
             get => GetValue(WrapProperty);
@@ -127,8 +157,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the column spacing
+        /// Gets or sets the minimum horizontal spacing between child controls or lines,
+        /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
+        /// <remarks>
+        /// Similar to CSS column-gap property.
+        /// </remarks>
         public double ColumnSpacing
         {
             get => GetValue(ColumnSpacingProperty);
@@ -136,8 +170,12 @@ namespace Avalonia.Labs.Panels
         }
 
         /// <summary>
-        /// Gets or sets the row spacing
+        /// Gets or sets the minimum vertical spacing between child controls or lines,
+        /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
+        /// <remarks>
+        /// Similar to CSS row-gap property.
+        /// </remarks>
         public double RowSpacing
         {
             get => GetValue(RowSpacingProperty);

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -95,6 +95,7 @@ namespace Avalonia.Labs.Panels
         /// determining the orientation in which child controls are laid out.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to <see cref="FlexDirection.Row"/>.
         /// Equivalent to CSS flex-direction property
         /// </remarks>
         public FlexDirection Direction
@@ -108,6 +109,7 @@ namespace Avalonia.Labs.Panels
         /// Typically used to distribute extra free space leftover after flexible lengths and margins have been resolved.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to <see cref="JustifyContent.FlexStart"/>.
         /// Equivalent to CSS justify-content property.
         /// </remarks>
         public JustifyContent JustifyContent
@@ -121,6 +123,7 @@ namespace Avalonia.Labs.Panels
         /// Similar to <see cref="JustifyContent"/>, but in the perpendicular direction.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to <see cref="AlignItems.Stretch"/>.
         /// Equivalent to CSS align-items property.
         /// </remarks>
         public AlignItems AlignItems
@@ -135,6 +138,7 @@ namespace Avalonia.Labs.Panels
         /// Useful when <see cref="Wrap"/> mode allows controls to be arranged on multiple lines. 
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to <see cref="AlignContent.Stretch"/>.
         /// Equivalent to CSS align-content property.
         /// </remarks>
         public AlignContent AlignContent
@@ -148,6 +152,7 @@ namespace Avalonia.Labs.Panels
         /// Additionally, it determines the cross-axis stacking direction for new lines.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to <see cref="FlexWrap.NoWrap"/>.
         /// Equivalent to CSS flex-wrap property.
         /// </remarks>
         public FlexWrap Wrap
@@ -161,6 +166,7 @@ namespace Avalonia.Labs.Panels
         /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to 0.
         /// Similar to CSS column-gap property.
         /// </remarks>
         public double ColumnSpacing
@@ -174,6 +180,7 @@ namespace Avalonia.Labs.Panels
         /// depending on main-axis direction of the <see cref="FlexPanel"/>.
         /// </summary>
         /// <remarks>
+        /// When omitted, it is set to 0.
         /// Similar to CSS row-gap property.
         /// </remarks>
         public double RowSpacing

--- a/src/Avalonia.Labs.Panels/FlexWrap.cs
+++ b/src/Avalonia.Labs.Panels/FlexWrap.cs
@@ -8,6 +8,9 @@
         /// <summary>
         /// The <see cref="FlexPanel"/> is single line.
         /// </summary>
+        /// <remarks>
+        /// This is the default value.
+        /// </remarks>
         NoWrap,
         
         /// <summary>

--- a/src/Avalonia.Labs.Panels/FlexWrap.cs
+++ b/src/Avalonia.Labs.Panels/FlexWrap.cs
@@ -1,9 +1,23 @@
 ﻿namespace Avalonia.Labs.Panels
 {
+    /// <summary>
+    /// Describes the wrap behavior of the <see cref="FlexPanel"/>
+    /// </summary>
     public enum FlexWrap
     {
+        /// <summary>
+        /// The <see cref="FlexPanel"/> is single line.
+        /// </summary>
         NoWrap,
+        
+        /// <summary>
+        /// The <see cref="FlexPanel"/> is multi line.
+        /// </summary>
         Wrap,
+        
+        /// <summary>
+        /// Same as <see cref="Wrap"/> but new lines are added in the opposite cross-axis direction.
+        /// </summary>
         WrapReverse
     }
 }

--- a/src/Avalonia.Labs.Panels/JustifyContent.cs
+++ b/src/Avalonia.Labs.Panels/JustifyContent.cs
@@ -2,7 +2,7 @@
 {
     
     /// <summary>
-    /// Describes the alignment of the children along the main axis of the <see cref="FlexPanel"/>.
+    /// Describes the main-axis alignment of items inside a <see cref="FlexPanel"/> line.
     /// </summary>
     public enum JustifyContent
     {
@@ -37,7 +37,7 @@
         Center,
         
         /// <summary>
-        /// Child items are evenly distributed in the line.
+        /// Child items are evenly distributed in the line, with no space on either end.
         /// </summary>
         /// <remarks>
         /// If the leftover free-space is negative or there is only a single child item on the line,
@@ -60,7 +60,7 @@
         SpaceAround,
         
         /// <summary>
-        /// Child items are evenly distributed in the line, with equal-size spaces between each child item and with the start/end of the line.
+        /// Child items are evenly distributed in the line, with equal-size spaces between each item and on either end.
         /// </summary>
         SpaceEvenly
     }

--- a/src/Avalonia.Labs.Panels/JustifyContent.cs
+++ b/src/Avalonia.Labs.Panels/JustifyContent.cs
@@ -1,12 +1,67 @@
 ﻿namespace Avalonia.Labs.Panels
 {
+    
+    /// <summary>
+    /// Describes the alignment of the children along the main axis of the <see cref="FlexPanel"/>.
+    /// </summary>
     public enum JustifyContent
     {
+        /// <summary>
+        /// Child items are packed toward the start of the line.
+        /// </summary>
+        /// <remarks>
+        /// This is the default value.
+        /// The main-axis start margin edge of the first child item on the line is placed flush with the start edge of the line,
+        /// and each subsequent child item is placed flush with the preceding item.
+        /// </remarks>
         FlexStart,
+        
+        /// <summary>
+        /// Child items are packed toward the end of the line.
+        /// </summary>
+        /// <remarks>
+        /// The main-axis margin edge of the last child item is placed flush with the end edge of the line,
+        /// and each preceding child item is placed flush with the subsequent item.
+        /// </remarks>
         FlexEnd,
+        
+        /// <summary>
+        /// Child items are packed toward the center of the line.
+        /// </summary>
+        /// <remarks>
+        /// The child items on the line are placed flush with each other and aligned in the center of the line,
+        /// with equal amounts of space between the main-axis start edge of the line and the first item on the line
+        /// and between the main-axis end edge of the line and the last item on the line.
+        /// If the leftover free-space is negative, the child items will overflow equally in both directions.
+        /// </remarks>
         Center,
+        
+        /// <summary>
+        /// Child items are evenly distributed in the line.
+        /// </summary>
+        /// <remarks>
+        /// If the leftover free-space is negative or there is only a single child item on the line,
+        /// this value is identical to <see cref="FlexStart"/>.
+        /// Otherwise, the main-axis start margin edge of the first child item on the line is placed flush with the main-axis start edge of the line,
+        /// the main-axis end margin edge of the last child item on the line is placed flush with the main-axis end edge of the line,
+        /// and the remaining child items on the line are distributed so that the spacing between any two adjacent items is the same.
+        /// </remarks>
         SpaceBetween,
+        
+        /// <summary>
+        /// Child items are evenly distributed in the line, with half-size spaces on either end.
+        /// </summary>
+        /// <remarks>
+        /// If the leftover free-space is negative or there is only a single child item on the line,
+        /// this value is identical to <see cref="Center"/>.
+        /// Otherwise, the child items on the line are distributed such that the spacing between any two adjacent child items on the line is the same,
+        /// and the spacing between the first/last child items and the <see cref="FlexPanel"/> edges is half the size of the spacing between child items.
+        /// </remarks>
         SpaceAround,
+        
+        /// <summary>
+        /// Child items are evenly distributed in the line, with equal-size spaces between each child item and with the start/end of the line.
+        /// </summary>
         SpaceEvenly
     }
 }

--- a/src/Avalonia.Labs.Panels/JustifyContent.cs
+++ b/src/Avalonia.Labs.Panels/JustifyContent.cs
@@ -11,27 +11,18 @@
         /// </summary>
         /// <remarks>
         /// This is the default value.
-        /// The main-axis start margin edge of the first child item on the line is placed flush with the start edge of the line,
-        /// and each subsequent child item is placed flush with the preceding item.
         /// </remarks>
         FlexStart,
         
         /// <summary>
         /// Child items are packed toward the end of the line.
         /// </summary>
-        /// <remarks>
-        /// The main-axis margin edge of the last child item is placed flush with the end edge of the line,
-        /// and each preceding child item is placed flush with the subsequent item.
-        /// </remarks>
         FlexEnd,
         
         /// <summary>
         /// Child items are packed toward the center of the line.
         /// </summary>
         /// <remarks>
-        /// The child items on the line are placed flush with each other and aligned in the center of the line,
-        /// with equal amounts of space between the main-axis start edge of the line and the first item on the line
-        /// and between the main-axis end edge of the line and the last item on the line.
         /// If the leftover free-space is negative, the child items will overflow equally in both directions.
         /// </remarks>
         Center,
@@ -42,9 +33,6 @@
         /// <remarks>
         /// If the leftover free-space is negative or there is only a single child item on the line,
         /// this value is identical to <see cref="FlexStart"/>.
-        /// Otherwise, the main-axis start margin edge of the first child item on the line is placed flush with the main-axis start edge of the line,
-        /// the main-axis end margin edge of the last child item on the line is placed flush with the main-axis end edge of the line,
-        /// and the remaining child items on the line are distributed so that the spacing between any two adjacent items is the same.
         /// </remarks>
         SpaceBetween,
         
@@ -54,8 +42,6 @@
         /// <remarks>
         /// If the leftover free-space is negative or there is only a single child item on the line,
         /// this value is identical to <see cref="Center"/>.
-        /// Otherwise, the child items on the line are distributed such that the spacing between any two adjacent child items on the line is the same,
-        /// and the spacing between the first/last child items and the <see cref="FlexPanel"/> edges is half the size of the spacing between child items.
         /// </remarks>
         SpaceAround,
         


### PR DESCRIPTION
- resolves https://github.com/Nexus-Mods/NexusMods.App/issues/1754

This adds Docs comments on most `FlexPanel` properties and property enum values.

This should make usage of the panel easier for both developers that are not already familiar with `flexbox`, as well for developers that are.

The [CSS FlexBox Specification](https://www.w3.org/TR/css-flexbox-1//) was used as a starting point for the comments and adapted for `FlexPanel` semantics.

