### PR TITLE
Fix `FlexPanel` division by 0 crashes and cleanup

### DIFF
--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -243,6 +243,7 @@ namespace Avalonia.Labs.Panels
             {
                 var (itemsCount, totalSpacingU, totalU, freeU) = GetLineMeasureU(flexLine, max.U, spacing.U);
                 var (lineMult, autoMargins, remainingFreeU) = GetLineMultInfo(flexLine, freeU);
+                
                 if (lineMult != 0.0 && remainingFreeU != 0.0)
                 {
                     foreach (var element in state.GetLineItems(flexLine))

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -286,17 +286,7 @@ namespace Avalonia.Labs.Panels
 
             var alignContent = DetermineAlignContent(AlignContent, freeV, linesCount);
 
-            var (spacingV, v) = alignContent switch
-            {
-                AlignContent.FlexStart => (spacing.V, 0.0),
-                AlignContent.FlexEnd => (spacing.V, freeV),
-                AlignContent.Center => (spacing.V, freeV / 2),
-                AlignContent.Stretch => (spacing.V, 0.0),
-                AlignContent.SpaceBetween => linesCount > 1 ? (spacing.V + freeV / (linesCount - 1), 0.0) : (spacing.V, 0.0),
-                AlignContent.SpaceAround => linesCount > 0 ? (spacing.V + freeV / linesCount, freeV / linesCount / 2) : (spacing.V, freeV / 2),
-                AlignContent.SpaceEvenly => (spacing.V + freeV / (linesCount + 1), freeV / (linesCount + 1)),
-                _ => throw new InvalidOperationException()
-            };
+            var (v, spacingV) = DetermineCrossAxisPositionAndSpacing(alignContent, spacing, freeV, linesCount);
 
             var scaleV = alignContent == AlignContent.Stretch && totalLineV != 0 ? (panelSize.V - totalSpacingV) / totalLineV : 1.0;
 
@@ -396,6 +386,24 @@ namespace Avalonia.Labs.Panels
                 AlignContent.FlexStart or AlignContent.Center or AlignContent.FlexEnd => currentAlignContent,
                 
                 _ => throw new InvalidOperationException($"Unsupported AlignContent value: {currentAlignContent}")
+            };
+        }
+        
+        private static (double v, double spacingV) DetermineCrossAxisPositionAndSpacing(AlignContent alignContent, Uv spacing, double freeV, int linesCount)
+        {
+            return alignContent switch
+            {
+                AlignContent.FlexStart => (0.0, spacing.V),
+                AlignContent.FlexEnd => (freeV, spacing.V),
+                AlignContent.Center => (freeV / 2, spacing.V),
+                AlignContent.Stretch => (0.0, spacing.V),
+                AlignContent.SpaceBetween when linesCount > 1 => (0.0, spacing.V + freeV / (linesCount - 1)),
+                AlignContent.SpaceBetween => (0.0, spacing.V),
+                AlignContent.SpaceAround when linesCount > 0 =>  (freeV / linesCount / 2, spacing.V + freeV / linesCount),
+                AlignContent.SpaceAround => (freeV / 2, spacing.V),
+                AlignContent.SpaceEvenly => (freeV / (linesCount + 1), spacing.V + freeV / (linesCount + 1)),
+                
+                _ => throw new InvalidOperationException()
             };
         }
 

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 using Avalonia.Controls;
 using Avalonia.Layout;
-using Avalonia.Media.TextFormatting;
 
 namespace Avalonia.Labs.Panels
 {

--- a/src/Avalonia.Labs.Panels/FlexPanel.cs
+++ b/src/Avalonia.Labs.Panels/FlexPanel.cs
@@ -318,13 +318,13 @@ namespace Avalonia.Labs.Panels
                 AlignContent.FlexEnd => (spacing.V, freeV),
                 AlignContent.Center => (spacing.V, freeV / 2),
                 AlignContent.Stretch => (spacing.V, 0.0),
-                AlignContent.SpaceBetween => (spacing.V + freeV / (linesCount - 1), 0.0),
-                AlignContent.SpaceAround => (spacing.V + freeV / linesCount, freeV / linesCount / 2),
+                AlignContent.SpaceBetween => linesCount > 1 ? (spacing.V + freeV / (linesCount - 1), 0.0) : (spacing.V, 0.0),
+                AlignContent.SpaceAround => linesCount > 0 ? (spacing.V + freeV / linesCount, freeV / linesCount / 2) : (spacing.V, freeV / 2),
                 AlignContent.SpaceEvenly => (spacing.V + freeV / (linesCount + 1), freeV / (linesCount + 1)),
                 _ => throw new InvalidOperationException()
             };
 
-            var scaleV = alignContent == AlignContent.Stretch ? (panelSize.V - totalSpacingV) / totalLineV : 1.0;
+            var scaleV = alignContent == AlignContent.Stretch && totalLineV != 0 ? (panelSize.V - totalSpacingV) / totalLineV : 1.0;
 
             foreach (var line in state.Lines)
             {
@@ -370,9 +370,9 @@ namespace Avalonia.Labs.Panels
                     JustifyContent.FlexStart => (spacing.U, 0.0),
                     JustifyContent.FlexEnd => (spacing.U, remainingFreeU),
                     JustifyContent.Center => (spacing.U, remainingFreeU / 2),
-                    JustifyContent.SpaceBetween => (spacing.U + remainingFreeU / (itemsCount - 1), 0.0),
-                    JustifyContent.SpaceAround => (spacing.U + remainingFreeU / itemsCount, remainingFreeU / itemsCount / 2),
-                    JustifyContent.SpaceEvenly => (spacing.U + remainingFreeU / (itemsCount + 1), remainingFreeU / (itemsCount + 1)),
+                    JustifyContent.SpaceBetween => itemsCount > 1 ? (spacing.U + remainingFreeU / (itemsCount - 1), 0.0) : (spacing.U, 0.0),
+                    JustifyContent.SpaceAround => itemsCount > 0 ? (spacing.U + remainingFreeU / itemsCount, remainingFreeU / itemsCount / 2) : (spacing.U, remainingFreeU / 2),
+                    JustifyContent.SpaceEvenly => itemsCount > 0 ? (spacing.U + remainingFreeU / (itemsCount + 1), remainingFreeU / (itemsCount + 1)) : (spacing.U, remainingFreeU / 2),
                     _ => throw new InvalidOperationException()
                 };
 


### PR DESCRIPTION
## PR Details:
Fixed a few instances of possible divisions by 0 that caused NaN to propagate until exceptions would occur.
These would happen when available cross axis space was 0 or all child items had 0 main or cross axis size.

Checks were put in place to prevent any potential instance of division by zero, following the [FlexBox specification](https://www.w3.org/TR/css-flexbox-1/) on what behaviour to take in such cases.
See [2fbea8f](https://github.com/AvaloniaUI/Avalonia.Labs/commit/2fbea8f117049e695dd6b90023494d0587807748) for fix details.

Minor refactoring was then done to improve code readability by extracting a few methods from `MeasureOverride` and `ArrangeOverride` and making the logic more concise and explicit.

### Problem Details:
Minimum code to reproduce the division by 0 issue:
```xml
<Border Height="100">
      <Grid RowDefinitions="Auto,*">
        <TextBlock Text="Text"/>
        <panels:FlexPanel Grid.Row="1" Wrap="Wrap">
          <Button Content="ButtonContent" Height="0"/>
        </panels:FlexPanel>
      </Grid>
</Border>
```
`AlignContent.Stretch` with `Wrap.Wrap` and items all contents with `Height="0"` inside a container with fixed Height.