### PR TITLE
Lottie playback controls

### DIFF
--- a/src/Avalonia.Labs.Lottie/Lottie.cs
+++ b/src/Avalonia.Labs.Lottie/Lottie.cs
@@ -179,8 +179,8 @@ public class Lottie : Control
         _customVisual.SendHandlerMessage(
             new LottiePayload(
                 LottieCommand.Update,
-                _animation,
-                Stretch,
+                _animation, 
+                Stretch, 
                 StretchDirection));
 
         if (AutoPlay)
@@ -211,9 +211,9 @@ public class Lottie : Control
         _customVisual.Size = new Vector2((float)Bounds.Size.Width, (float)Bounds.Size.Height);
         _customVisual.SendHandlerMessage(
             new LottiePayload(
-                LottieCommand.Update,
-                _animation,
-                Stretch,
+                LottieCommand.Update, 
+                _animation, 
+                Stretch, 
                 StretchDirection));
     }
 
@@ -308,8 +308,8 @@ public class Lottie : Control
 
     private SkiaSharp.Skottie.Animation? Load(string path, Uri? baseUri)
     {
-        var uri = path.StartsWith("/")
-            ? new Uri(path, UriKind.Relative)
+        var uri = path.StartsWith("/") 
+            ? new Uri(path, UriKind.Relative) 
             : new Uri(path, UriKind.RelativeOrAbsolute);
         if (uri.IsAbsoluteUri && uri.IsFile)
         {

--- a/src/Avalonia.Labs.Lottie/Lottie.cs
+++ b/src/Avalonia.Labs.Lottie/Lottie.cs
@@ -160,7 +160,7 @@ public class Lottie : Control
         {
             return;
         }
-
+        
         _customVisual = compositor.CreateCustomVisual(new LottieCompositionCustomVisualHandler());
         ElementComposition.SetElementChildVisual(this, _customVisual);
 

--- a/src/Avalonia.Labs.Lottie/Lottie.cs
+++ b/src/Avalonia.Labs.Lottie/Lottie.cs
@@ -57,7 +57,7 @@ public class Lottie : Control
     /// Defines the <see cref="AutoPlay"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> AutoPlayProperty =
-        AvaloniaProperty.Register<Lottie, bool>(nameof(AutoPlay));
+        AvaloniaProperty.Register<Lottie, bool>(nameof(AutoPlay), true);
 
     /// <summary>
     /// Gets or sets the Lottie animation path.

--- a/src/Avalonia.Labs.Lottie/LottieCommand.cs
+++ b/src/Avalonia.Labs.Lottie/LottieCommand.cs
@@ -5,5 +5,8 @@ internal enum LottieCommand
     Start,
     Stop,
     Update,
-    Dispose
+    Dispose,
+    Pause,
+    Resume,
+    Seek
 }

--- a/src/Avalonia.Labs.Lottie/LottieCompositionCustomVisualHandler.cs
+++ b/src/Avalonia.Labs.Lottie/LottieCompositionCustomVisualHandler.cs
@@ -12,6 +12,7 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
     private TimeSpan _primaryTimeElapsed, _animationElapsed;
     private TimeSpan? _lastServerTime;
     private bool _running;
+    private bool _paused;
     private SkiaSharp.Skottie.Animation? _animation;
     private Stretch? _stretch;
     private StretchDirection? _stretchDirection;
@@ -19,6 +20,8 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
     private readonly object _sync = new();
     private int _repeatCount;
     private int _count;
+    private Action? _onAnimationCompleted;
+    private Action<int>? _onAnimationCompletedRepetition;
 
     public override void OnMessage(object message)
     {
@@ -39,6 +42,7 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
             }:
             {
                 _running = true;
+                _paused = false;
                 _lastServerTime = null;
                 _stretch = st;
                 _stretchDirection = sd;
@@ -46,7 +50,41 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
                 _repeatCount = rp;
                 _count = 0;
                 _animationElapsed = TimeSpan.Zero;
+                _onAnimationCompleted = msg.OnAnimationCompleted;
+                _onAnimationCompletedRepetition = msg.OnAnimationCompletedRepetition;
                 RegisterForNextAnimationFrameUpdate();
+                break;
+            }
+            case
+            {
+                LottieCommand: LottieCommand.Pause
+            }:
+            {
+                _paused = true;
+                break;
+            }
+            case
+            {
+                LottieCommand: LottieCommand.Resume
+            }:
+            {
+                _paused = false;
+                RegisterForNextAnimationFrameUpdate();
+                break;
+            }
+            case
+            {
+                LottieCommand: LottieCommand.Seek
+            }:
+            {
+                if (msg.SeekFrame.HasValue)
+                {
+                    SeekToFrame(msg.SeekFrame.Value);
+                }
+                else if (msg.SeekProgress.HasValue)
+                {
+                    SeekToProgress(msg.SeekProgress.Value);
+                }
                 break;
             }
             case
@@ -84,16 +122,48 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
 
     public override void OnAnimationFrameUpdate()
     {
-        if (!_running)
+        if (!_running || _paused)
             return;
 
-
-        if (_repeatCount == 0 || (_repeatCount > 0 && _count >= _repeatCount))
+        if (_lastServerTime.HasValue)
         {
-            _running = false;
-            _animationElapsed = TimeSpan.Zero;
+            var delta = CompositionNow - _lastServerTime.Value;
+            _primaryTimeElapsed += delta;
+            _animationElapsed += delta;
         }
 
+        _lastServerTime = CompositionNow;
+
+        GetFrameTime(); // This will handle cycle completion and repetitions
+
+        if (!_running)
+            return; // Animation has completed all repetitions
+
+        Invalidate();
+        RegisterForNextAnimationFrameUpdate();
+    }
+
+    private void SeekToFrame(float frame)
+    {
+        if (_animation == null)
+        {
+            return;
+        }
+
+        _animationElapsed = TimeSpan.FromSeconds(frame / _animation.Fps);
+        Invalidate();
+        RegisterForNextAnimationFrameUpdate();
+    }
+
+    private void SeekToProgress(float progress)
+    {
+        if (_animation == null)
+        {
+            return;
+        }
+
+        progress = Math.Min(Math.Max(progress, 0), 1);
+        _animationElapsed = TimeSpan.FromSeconds(_animation.Duration.TotalSeconds * progress);
         Invalidate();
         RegisterForNextAnimationFrameUpdate();
     }
@@ -125,6 +195,19 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
             _ic?.End();
             _ic?.Begin();
             _count++;
+
+            if (_repeatCount != Lottie.Infinity && _count >= _repeatCount)
+            {
+                // Animation has finished all repetitions
+                _running = false;
+                _onAnimationCompleted?.Invoke();
+                return _animation.Duration.TotalSeconds; // Return the last frame
+            }
+
+            // Animation cycle completed, but not finished all repetitions
+            _onAnimationCompletedRepetition?.Invoke(_count);
+
+            frameTime = 0; // Reset frame time for the next cycle
         }
 
         return frameTime;
@@ -183,8 +266,8 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
                 _lastServerTime = CompositionNow;
             }
 
-            if (_animation is not { } an 
-                || _stretch is not { } st 
+            if (_animation is not { } an
+                || _stretch is not { } st
                 || _stretchDirection is not { } sd)
             {
                 return;

--- a/src/Avalonia.Labs.Lottie/LottieCompositionCustomVisualHandler.cs
+++ b/src/Avalonia.Labs.Lottie/LottieCompositionCustomVisualHandler.cs
@@ -269,8 +269,8 @@ internal class LottieCompositionCustomVisualHandler : CompositionCustomVisualHan
                 _lastServerTime = CompositionNow;
             }
 
-            if (_animation is not { } an
-                || _stretch is not { } st
+            if (_animation is not { } an 
+                || _stretch is not { } st 
                 || _stretchDirection is not { } sd)
             {
                 return;

--- a/src/Avalonia.Labs.Lottie/LottiePayload.cs
+++ b/src/Avalonia.Labs.Lottie/LottiePayload.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Media;
 
 namespace Avalonia.Labs.Lottie;
@@ -7,4 +8,8 @@ internal record struct LottiePayload(
     SkiaSharp.Skottie.Animation? Animation = null,
     Stretch? Stretch = null,
     StretchDirection? StretchDirection = null,
-    int? RepeatCount = null);
+    int? RepeatCount = null,
+    float? SeekFrame = null,
+    float? SeekProgress = null,
+    Action? OnAnimationCompleted = null,
+    Action<int>? OnAnimationCompletedRepetition = null);


### PR DESCRIPTION
Hi there! We found the Lottie control really useful to our project, thanks for maintaining it!

For our use case, we needed the ability to pause, resume, and skip through the animation, and also to have callbacks fired when the animation stops or loops.

This adds the following APIs:

* `Start()` and `Stop()` - existing methods, now made public
* `Pause()` and `Resume()` - same as above but retains the current frame
* `SeekToFrame(float frame)` - skip to an exact Lottie frame number
* `SeekToProgress(float progress)` - skip to frame by progress percentage value
* `AutoPlay` - can be used to prevent immediate playback (default `true` so behavior remains compatible)
* `OnAnimationCompleted` and `OnAnimationCompletedRepetition` event handlers - callback on animation stopping at the end, or completing a repetition.