### PR TITLE
#97 - fixing native notifications sample

### DIFF
--- a/samples/Avalonia.Labs.Catalog.Android/Properties/AndroidManifest.xml
+++ b/samples/Avalonia.Labs.Catalog.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 	<uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 	<application android:label="Avalonia.Labs.Catalog" android:icon="@drawable/Icon" />
 </manifest>

--- a/src/Avalonia.Labs.Notifications/Android/NativeNotification.cs
+++ b/src/Avalonia.Labs.Notifications/Android/NativeNotification.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Labs.Notifications.Android
                 .PutExtras(deleteBundle);
 
             var flags = Build.VERSION.SdkInt >= BuildVersionCodes.S ? PendingIntentFlags.Mutable : PendingIntentFlags.UpdateCurrent;
-
+            
             builder.SetContentIntent(PendingIntent.GetActivity(_activity, pendingIntentId + 1, tapIntent, flags))
                 .SetDeleteIntent(PendingIntent.GetBroadcast(_activity, pendingIntentId + 2, deleteIntent, flags));
 
@@ -130,7 +130,7 @@ namespace Avalonia.Labs.Notifications.Android
 
                 var actionIntent = new Intent(_activity, typeof(NotificationBroadcastReceiver))
                     .PutExtras(actionbundle);
-                var pendingIntent = PendingIntent.GetBroadcast(_activity, pendingIntentId + 3 + i, actionIntent, replyAction != null ? PendingIntentFlags.UpdateCurrent : flags);
+                var pendingIntent = PendingIntent.GetBroadcast(_activity, pendingIntentId + 3 + i, actionIntent, flags);
                 var notificationAction = new NotificationCompat.Action.Builder(icon, action.Caption, pendingIntent);
 
                 if (!string.IsNullOrWhiteSpace(ReplyActionTag) && replyAction == action)


### PR DESCRIPTION
- added missing permission to AndroidManifest.xml
- added "FlagMutable" to native notification, as otherwise a native notification with custom Actions or a Reply Action throws an 
> Java.Lang.IllegalArgumentException:

fixes #97 