### PR TITLE
Fix SKCanvasView render bounds

### DIFF
--- a/src/Avalonia.Labs.Controls/SKCanvasView/SKCanvasView.cs
+++ b/src/Avalonia.Labs.Controls/SKCanvasView/SKCanvasView.cs
@@ -171,7 +171,7 @@ public partial class SKCanvasView : Decorator
         base.Render(context);
         if (GetValue(BackgroundProperty) is IBrush background)
         {
-            context.FillRectangle(background, Bounds);
+            context.FillRectangle(background, new Rect(Bounds.Size));
         }
     }
 


### PR DESCRIPTION
This PR fixes the `SKCanvasView` not being rendered at 0,0.

Fixes #104 