### PR TITLE
string cannot be auto-converted into URI.

### DIFF
--- a/src/Avalonia.Labs.Controls/AsyncImage/AsyncImage.cs
+++ b/src/Avalonia.Labs.Controls/AsyncImage/AsyncImage.cs
@@ -77,8 +77,17 @@ namespace Avalonia.Labs.Controls
                 return;
             }
 
-            var uri = Source as Uri;
+            Uri? uri = null;
 
+            if (source is Uri sourceUri)
+            {
+                uri = sourceUri;
+            } 
+            else if (Source is string sourceString)
+            {
+                uri = new Uri(sourceString);
+            }
+            
             if (uri != null && uri.IsAbsoluteUri)
             {
                 if (uri.Scheme == "http" || uri.Scheme == "https")


### PR DESCRIPTION
If Source is string, create a new URI

Fixes #106 

@grokys could this be related to Bindings refractor? If so, do we want a tracking issue in Avalonia?