### PR TITLE
GifImage improvements

### DIFF
--- a/src/Avalonia.Labs.Gif/GifCompositionCustomVisualHandler.cs
+++ b/src/Avalonia.Labs.Gif/GifCompositionCustomVisualHandler.cs
@@ -28,25 +28,7 @@ internal class GifCompositionCustomVisualHandler : CompositionCustomVisualHandle
         {
             case
             {
-                HandlerCommand: HandlerCommand.Start, Source: { } uri, IterationCount: { } iteration,
-                Stretch: { } st, StretchDirection: { } sd
-            }:
-            {
-                _gifInstance = new GifInstance(uri);
-
-                _gifInstance.IterationCount = iteration;
-
-                _lastServerTime = CompositionNow;
-                _GifSize = _gifInstance.GifPixelSize.ToSize(1);
-                _running = true;
-                _stretch = st;
-                _stretchDirection = sd;
-                RegisterForNextAnimationFrameUpdate();
-                break;
-                }
-            case
-            {
-                HandlerCommand: HandlerCommand.Start, SourceStream: { } stream, IterationCount: { } iteration,
+                HandlerCommand: HandlerCommand.Start, Source: { } stream, IterationCount: { } iteration,
                 Stretch: { } st, StretchDirection: { } sd
             }:
             {

--- a/src/Avalonia.Labs.Gif/GifDrawPayload.cs
+++ b/src/Avalonia.Labs.Gif/GifDrawPayload.cs
@@ -7,8 +7,7 @@ namespace Avalonia.Labs.Gif;
 
 internal record struct GifDrawPayload(
     HandlerCommand HandlerCommand,
-    Stream? SourceStream = default,
-    Uri? Source = default,
+    Stream? Source = default,
     Size? GifSize = default,
     Size? Size = default,
     Stretch? Stretch = default,

--- a/src/Avalonia.Labs.Gif/GifInstance.cs
+++ b/src/Avalonia.Labs.Gif/GifInstance.cs
@@ -29,10 +29,6 @@ internal class GifInstance : IDisposable
     })
     {
     }
-    
-    public GifInstance(Uri uri) : this(AssetLoader.Open(uri))
-    {
-    }
 
     private GifInstance(Stream currentStream)
     {


### PR DESCRIPTION
Some improvements of PR #108:
1. Unification of `Source` and `SourceStream` properties.
2. Added the ability to load a GIF from uri in string format (e.g. for use in Xaml).
3. Removed an unused `public` constructor from the `internal` class `GifInstance`.