### PR TITLE
Add ClearOnClose notification api

### DIFF
--- a/src/Avalonia.Labs.Notifications/Android/NativeNotificationManager.cs
+++ b/src/Avalonia.Labs.Notifications/Android/NativeNotificationManager.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Labs.Notifications.Android
 
         public AndroidNotificationChannelManager ChannelManager { get; }
         NotificationChannelManager INativeNotificationManagerImpl.ChannelManager => ChannelManager;
+        public bool ClearOnClose { get; set; }
 
         public event EventHandler<NativeNotificationCompletedEventArgs>? NotificationCompleted;
 
@@ -127,7 +128,8 @@ namespace Avalonia.Labs.Notifications.Android
 
         public void Dispose()
         {
-            // no-op
+            if (ClearOnClose)
+                CloseAll();
         }
     }
 }

--- a/src/Avalonia.Labs.Notifications/AppBuilderExtensions.cs
+++ b/src/Avalonia.Labs.Notifications/AppBuilderExtensions.cs
@@ -55,6 +55,8 @@ namespace Avalonia.Labs.Notifications
                 notificationManager.ChannelManager.AddChannel(channel);
             }
 
+            notificationManager.ClearOnClose = options?.ClearOnAppClose ?? false;
+
             return appBuilder.AfterSetup((a) =>
             {
                 notificationManager.Initialize(options);

--- a/src/Avalonia.Labs.Notifications/AppNotificationOptions.cs
+++ b/src/Avalonia.Labs.Notifications/AppNotificationOptions.cs
@@ -46,4 +46,9 @@ public class AppNotificationOptions
 #endif
 
     public IReadOnlyList<NotificationChannel>? Channels { get; init; }
+
+    /// <summary>
+    /// Clears all notifications when the Avalonia app shutdowns
+    /// </summary>
+    public bool ClearOnAppClose { get; set; }
 }

--- a/src/Avalonia.Labs.Notifications/Apple/AppleNativeNotificationManager.cs
+++ b/src/Avalonia.Labs.Notifications/Apple/AppleNativeNotificationManager.cs
@@ -23,6 +23,7 @@ internal class AppleNativeNotificationManager : INativeNotificationManagerImpl, 
     }
 
     public AppleNotificationChannelManager ChannelManager { get; }
+    public bool ClearOnClose { get; set; }
     NotificationChannelManager INativeNotificationManagerImpl.ChannelManager => ChannelManager;
 
     public IReadOnlyDictionary<uint, INativeNotification> ActiveNotifications =>
@@ -77,6 +78,9 @@ internal class AppleNativeNotificationManager : INativeNotificationManagerImpl, 
 
     public void Dispose()
     {
+        if (ClearOnClose)
+            CloseAll();
+
         _notificationDelegate.DidReceiveNotificationResponse -= NotificationDelegateOnDidReceiveNotificationResponse;
         UNUserNotificationCenter.Current.Delegate = null;
     }

--- a/src/Avalonia.Labs.Notifications/INativeNotification.cs
+++ b/src/Avalonia.Labs.Notifications/INativeNotification.cs
@@ -53,6 +53,7 @@ namespace Avalonia.Labs.Notifications
     {
         void Initialize(AppNotificationOptions? options);
         NotificationChannelManager ChannelManager { get; }
+        bool ClearOnClose { get; set; }
     }
 
     public class NativeNotificationCompletedEventArgs : EventArgs

--- a/src/Avalonia.Labs.Notifications/Linux/LinuxNativeNotificationManager.cs
+++ b/src/Avalonia.Labs.Notifications/Linux/LinuxNativeNotificationManager.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Labs.Notifications.Linux
         public IReadOnlyDictionary<uint, INativeNotification> ActiveNotifications => _notifications;
 
         public NotificationChannelManager ChannelManager { get; } = new();
+        public bool ClearOnClose { get; set; }
 
         public async void Initialize(AppNotificationOptions? options)
         {
@@ -118,6 +119,9 @@ namespace Avalonia.Labs.Notifications.Linux
         /// <inheritdoc />
         public void Dispose()
         {
+            if (ClearOnClose)
+                CloseAll();
+
             _signalWatcher?.Dispose();
         }
 

--- a/src/Avalonia.Labs.Notifications/Windows/NativeNotificationManager.cs
+++ b/src/Avalonia.Labs.Notifications/Windows/NativeNotificationManager.cs
@@ -24,6 +24,7 @@ namespace Avalonia.Labs.Notifications.Windows
         public IReadOnlyDictionary<uint, INativeNotification> ActiveNotifications => _notifications;
 
         public NotificationChannelManager ChannelManager { get; }
+        public bool ClearOnClose { get; set; }
         public NativeNotificationManager()
         {
             ChannelManager = new NotificationChannelManager();
@@ -158,7 +159,7 @@ namespace Avalonia.Labs.Notifications.Windows
 
             _notifications.Clear();
 
-            if (!DesktopBridgeHelpers.HasPackage())
+            if (ClearOnClose)
             {
                 CloseAll();
             }


### PR DESCRIPTION
Adds `AppNotificationOptions.ClearOnClose`, defaulting to false, which instructs the notification manager to clear all notification when the app is closed.
Fixes https://github.com/AvaloniaUI/Avalonia.Labs/issues/122