### PR TITLE
Add ContentDialog.ShowAsync overload that takes toplevel

### DIFF
--- a/samples/Avalonia.Labs.Catalog/ViewModels/ContentDialogViewModel.cs
+++ b/samples/Avalonia.Labs.Catalog/ViewModels/ContentDialogViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Labs.Catalog.Views;
 using Avalonia.Labs.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -58,7 +59,7 @@ public partial class ContentDialogViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial bool IsSecondaryButtonEnabled { get; set; } = true;
-
+    public TopLevel? TopLevel { get; internal set; }
 
     public async void LaunchDialog(object? parameter)
     {
@@ -104,12 +105,12 @@ public partial class ContentDialogViewModel : ViewModelBase
         if (hasDeferral)
         {
             dialog.PrimaryButtonClick += OnPrimaryButtonClick;
-            await dialog.ShowAsync();
+            await dialog.ShowAsync(TopLevel);
             dialog.PrimaryButtonClick -= OnPrimaryButtonClick;
         }
         else
         {
-            await dialog.ShowAsync();
+            await dialog.ShowAsync(TopLevel);
         }
     }
 

--- a/samples/Avalonia.Labs.Catalog/Views/ContentDialogView.axaml.cs
+++ b/samples/Avalonia.Labs.Catalog/Views/ContentDialogView.axaml.cs
@@ -1,5 +1,7 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Labs.Catalog.ViewModels;
 using Avalonia.Markup.Xaml;
 
 namespace Avalonia.Labs.Catalog.Views;
@@ -9,5 +11,15 @@ public partial class ContentDialogView : UserControl
     public ContentDialogView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if(DataContext is ContentDialogViewModel vm)
+        {
+            vm.TopLevel = TopLevel.GetTopLevel(this);
+        }
     }
 }

--- a/src/Avalonia.Labs.Controls/ContentDialog/ContentDialog.cs
+++ b/src/Avalonia.Labs.Controls/ContentDialog/ContentDialog.cs
@@ -132,7 +132,12 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     /// <summary>
     /// Begins an asynchronous operation to show the dialog using the specified window
     /// </summary>
-    public async Task<ContentDialogResult> ShowAsync(Window w) => await ShowAsyncCore(w);
+    public async Task<ContentDialogResult> ShowAsync(Window window) => await ShowAsyncCore(window);
+
+    /// <summary>
+    /// Begins an asynchronous operation to show the dialog using the specified toplevel
+    /// </summary>
+    public async Task<ContentDialogResult> ShowAsync(TopLevel? toplevel) => await ShowAsyncCore(toplevel);
 
     /// <summary>
     /// Shows the content dialog on the specified window asynchronously.
@@ -140,7 +145,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     /// <remarks>
     /// Note that the placement parameter is not implemented and only accepts <see cref="ContentDialogPlacement.Popup"/>
     /// </remarks>
-    private async Task<ContentDialogResult> ShowAsyncCore(Window? window, ContentDialogPlacement placement = ContentDialogPlacement.Popup)
+    private async Task<ContentDialogResult> ShowAsyncCore(TopLevel? toplevel, ContentDialogPlacement placement = ContentDialogPlacement.Popup)
     {
         if (placement == ContentDialogPlacement.InPlace)
             throw new NotImplementedException("InPlace not implemented yet");
@@ -174,7 +179,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         _host.Content = this;
 
         OverlayLayer? ol = null;
-        var topLevel = GetTopLevel(window);
+        var topLevel = GetTopLevel(toplevel);
 
         ol = OverlayLayer.GetOverlayLayer(topLevel!);
         _lastFocus = topLevel!.FocusManager?.GetFocusedElement();
@@ -203,9 +208,9 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         ShowCore();
         return await _tcs.Task;
 
-        static TopLevel GetTopLevel(Window? window)
+        static TopLevel GetTopLevel(TopLevel? toplevel)
         {
-            return window ??
+            return toplevel ??
                 Application.Current!.ApplicationLifetime switch
                 {
                     IClassicDesktopStyleApplicationLifetime cls when cls.MainWindow is not null =>


### PR DESCRIPTION
With V12, Android backend no longer uses `ISingleViewApplicationLifetime`. So content dialog, which attempts to get the main view using the lifecycle, fails to show and crashes with `InvalidOperationException`.
This PR adds an overload for `ContentDialog.ShowAsync` which receives a `Toplevel` instance. This allow manually setting the toplevel the content dialog is shown on.