### PR TITLE
Generate CycloneDX SBOMs for the shipped NuGet packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-common"]
+	path = build-common
+	url = https://github.com/AvaloniaUI/build-common

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "CreateSbom"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
+      "properties": {
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "description": "Host for execution. Default is 'automatic'",
+          "$ref": "#/definitions/Host"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Output": {
+          "type": "string",
+          "description": "Directory the generated SBOMs are written to"
+        },
+        "Packages": {
+          "type": "string",
+          "description": "Directory containing the built .nupkg files to generate SBOMs for"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "./build.schema.json"
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
 pool:
     vmImage: 'windows-2022'
 steps:
+    - checkout: self
+      submodules: true
     - task: UseDotNet@2
       displayName: Use .NET SDK
       inputs:
@@ -20,9 +22,21 @@ steps:
           command: pack
           outputDir: $(Build.ArtifactStagingDirectory)/NuGet
           verbosityPack: normal
+    # Generates a per-package CycloneDX SBOM (EU CRA evidence) and embeds it into each .nupkg,
+    # so it must run after Pack and before the packages are published.
+    - task: CmdLine@2
+      displayName: Generate SBOMs
+      inputs:
+          script: dotnet run --project build/_build.csproj -- --packages "$(Build.ArtifactStagingDirectory)/NuGet" --output "$(Build.ArtifactStagingDirectory)/SBOM"
     - task: PublishBuildArtifacts@1
       displayName: Publish Build Artifacts
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)/NuGet
           artifactName: NuGet
+      condition: succeeded()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish SBOM Artifacts
+      inputs:
+          pathtoPublish: $(Build.ArtifactStagingDirectory)/SBOM
+          artifactName: SBOM
       condition: succeeded()

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,31 @@
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tooling;
+using NukeExtensions;
+
+// Packaging in this repository is plain `dotnet pack` driven by azure-pipelines.yml; this
+// minimal nuke build exists only to run the shared SBOM generation from build-common over
+// the packed output. Each package's version is read from its own .nuspec, so no version
+// computation is duplicated here.
+class Build : NukeBuild
+{
+    public static int Main() => Execute<Build>(x => x.CreateSbom);
+
+    [NuGetPackage("CycloneDX", "CycloneDX.dll", Framework = "net10.0")] readonly Tool CycloneDx = null!;
+
+    [Parameter("Directory containing the built .nupkg files to generate SBOMs for")]
+    readonly AbsolutePath Packages = RootDirectory / "artifacts" / "packages";
+
+    [Parameter("Directory the generated SBOMs are written to")]
+    readonly AbsolutePath Output = RootDirectory / "artifacts" / "sbom";
+
+    // Generates a per-package CycloneDX SBOM for EU Cyber Resilience Act evidence and embeds
+    // it into each .nupkg at _manifest/cyclonedx/bom.cdx.json, so it must run after packing
+    // and before the packages are published.
+    Target CreateSbom => _ => _
+        .Executes(() => SbomGenerator.Generate(
+            CycloneDx,
+            RootDirectory,
+            Packages,
+            Output));
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169;NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <LangVersion>latest</LangVersion>
+    <!-- The build project pins its own tool versions; opt out of the repo's central management. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageDownload Include="CycloneDX" Version="[6.2.0]" />
+    <ProjectReference Include="../build-common/nuke/NukeExtensions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds per-package **CycloneDX SBOM** generation for all nine shipped Labs packages, as EU Cyber Resilience Act-style technical documentation (not strictly required for OSS, but produced the same way as for the commercial components). Uses the shared generator merged in AvaloniaUI/build-common#4; see AvaloniaUI/Avalonia.Controls.TreeDataGrid-Accelerate#169 for the pilot.

- Packaging here is plain `dotnet pack` driven by `azure-pipelines.yml`, so this adds the `build-common` submodule (public repo) and a minimal nuke build whose only target, `CreateSbom`, runs the shared generator over the packed output. Each package'"'"'s version is read from its own nuspec, so the MSBuild version computation is not duplicated.
- The pipeline gains a `Generate SBOMs` step between pack and publish (the SBOM is embedded into each `.nupkg` at `_manifest/cyclonedx/bom.cdx.json`, so ordering matters), a `SBOM` build artifact, and `submodules: true` on checkout.

## Test plan

- [x] Verified locally against a packed `Avalonia.Labs.Qr`: SBOM carries the nuspec version and MIT license, lists the resolved Avalonia dependencies, and the embedded copy is present in the `.nupkg`
- [ ] Azure Pipelines run on this PR validates the full nine-package path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qDKmcNFxV3Xk5PjTGKrK6