### PR TITLE
[Fix] Avoid scheduling frames for static animated images

### DIFF
--- a/src/Avalonia.Labs.AnimatedImage/AnimatedImage.cs
+++ b/src/Avalonia.Labs.AnimatedImage/AnimatedImage.cs
@@ -252,7 +252,7 @@ public class AnimatedImage : Control
             {
                 _running = true;
                 _lastServerTime = null;
-                RegisterForNextAnimationFrameUpdate();
+                ScheduleAnimationFrameUpdate();
             }
             else if (message == StopMessage)
                 _running = false;
@@ -279,6 +279,9 @@ public class AnimatedImage : Control
                             _totalTime += delay;
                         }
 
+                        // A single-frame bitmap is still represented by IAnimatedBitmap,
+                        // but it does not need a composition callback for every frame.
+                        ScheduleAnimationFrameUpdate();
                         Invalidate();
 
                         break;
@@ -299,7 +302,13 @@ public class AnimatedImage : Control
             if (!_running)
                 return;
             Invalidate();
-            RegisterForNextAnimationFrameUpdate();
+            ScheduleAnimationFrameUpdate();
+        }
+
+        private void ScheduleAnimationFrameUpdate()
+        {
+            if (_running && _currentInstance is { FrameCount: > 1 })
+                RegisterForNextAnimationFrameUpdate();
         }
 
         public override void OnRender(ImmediateDrawingContext drawingContext)


### PR DESCRIPTION
## What changed

Avoid scheduling compositor animation-frame callbacks for static (`FrameCount == 1`) animated images.

## Why

`IAnimatedBitmap` represents both static and animated images. `AnimatedImage` previously registered a new animation-frame callback whenever playback started and after every callback, even when the source had only one frame. Each static image therefore kept invalidating and rendering on the compositor thread while idle. This is especially expensive when many avatar images are present.

The fix centralizes frame scheduling and only registers the next callback when the current source has more than one frame. Static images are still invalidated once when their source is assigned and continue to render normally; multi-frame images retain their existing playback behavior.