### PR TITLE
fix: some warnings

### DIFF
--- a/samples/Avalonia.Labs.Catalog/Views/ContentDialogInputExample.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/ContentDialogInputExample.axaml
@@ -10,7 +10,7 @@
   <StackPanel Spacing="10" MinWidth="400">
     <TextBlock>Try out some magic keywords</TextBlock>
     <AutoCompleteBox FilterMode="StartsWithOrdinal"
-                     Watermark="Write a keyword, for example 'ok', 'not ok' or 'hide'"
+                     PlaceholderText="Write a keyword, for example 'ok', 'not ok' or 'hide'"
                      Text="{CompiledBinding UserInput}"
                      ItemsSource="{Binding AvailableKeyWords}"
                      AttachedToVisualTree="InputField_OnAttachedToVisualTree" />

--- a/samples/Avalonia.Labs.Catalog/Views/NativeNotifications.axaml
+++ b/samples/Avalonia.Labs.Catalog/Views/NativeNotifications.axaml
@@ -14,7 +14,7 @@
               <Button Command="{Binding SendPredefinedActionsNotification}" HorizontalAlignment="Stretch">Send Notification With Predefined Actions</Button>
               <Button Command="{Binding SendCustomActionsNotification}"
                       HorizontalAlignment="Stretch">Send Notification With Custom Actions</Button>
-              <TextBox Watermark="Custom Action Caption" Text="{Binding CustomCaption}"/>
+              <TextBox PlaceholderText="Custom Action Caption" Text="{Binding CustomCaption}"/>
               <Button Command="{Binding SendReplyActionNotification}"
                       HorizontalAlignment="Stretch">Send Notification with Reply Action</Button>
               <Label Content="{Binding Response}"/>

--- a/src/Avalonia.Labs.Controls/FlipView/FlipView.cs
+++ b/src/Avalonia.Labs.Controls/FlipView/FlipView.cs
@@ -32,7 +32,8 @@ namespace Avalonia.Labs.Controls
         /// <summary>
         /// Defines the <see cref="IsButtonsVisible"/> property.
         /// </summary>
-        public static StyledProperty<bool> IsButtonsVisibleProperty = AvaloniaProperty.Register<FlipView, bool>(nameof(IsButtonsVisible), defaultValue: true);
+        public static readonly StyledProperty<bool> IsButtonsVisibleProperty = 
+            AvaloniaProperty.Register<FlipView, bool>(nameof(IsButtonsVisible), defaultValue: true);
 
         /// <summary>
         /// Defines the <see cref="TransitionDuration"/> property.


### PR DESCRIPTION
## Description

This PR includes minor fixes and property deprecation cleanups across the controls library and catalog samples:

1. **FlipView Property Modifier**: Added `readonly` modifier to `IsButtonsVisibleProperty` in `FlipView` to adhere to standard Avalonia property declarations.
2. **Catalog Samples Modernization**: Replaced deprecated/legacy `Watermark` attributes with `PlaceholderText` in `TextBox` and `AutoCompleteBox` across sample views.

## Changes

- **`src/Avalonia.Labs.Controls/FlipView/FlipView.cs`**:
  - Made `IsButtonsVisibleProperty` a `public static readonly StyledProperty<bool>`.
- **`samples/Avalonia.Labs.Catalog/Views/ContentDialogInputExample.axaml`**:
  - Updated `Watermark` to `PlaceholderText` on `AutoCompleteBox`.
- **`samples/Avalonia.Labs.Catalog/Views/NativeNotifications.axaml`**:
  - Updated `Watermark` to `PlaceholderText` on `TextBox`.

## Types of changes
- [x] Bug fix / Code cleanup (non-breaking change)
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the code style of this project.
- [x] Samples have been updated accordingly.
